### PR TITLE
feat: Create section for instance details

### DIFF
--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -28,6 +28,12 @@
   "plan",
   "auto_add_storage_min",
   "auto_add_storage_max",
+  "instance_details_section",
+  "instance_type",
+  "vcpu",
+  "instance_ram",
+  "column_break_rxox",
+  "volume_size",
   "networking_section",
   "ip",
   "instance_id",
@@ -565,10 +571,44 @@
    "fieldtype": "Data",
    "label": "Database Name",
    "set_only_once": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "instance_details_section",
+   "fieldtype": "Section Break",
+   "label": "Instance Details"
+  },
+  {
+   "fieldname": "instance_type",
+   "fieldtype": "Data",
+   "label": "Instance Type",
+   "read_only": 1
+  },
+  {
+   "fieldname": "vcpu",
+   "fieldtype": "Int",
+   "label": "vCPU",
+   "read_only": 1
+  },
+  {
+   "fieldname": "instance_ram",
+   "fieldtype": "Int",
+   "label": "RAM (MB)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_rxox",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "volume_size",
+   "fieldtype": "Int",
+   "label": "Volume Size (GB)",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-01-23 14:19:42.928641",
+ "modified": "2025-01-23 17:35:47.716866",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1312,6 +1312,8 @@ class Server(BaseServer):
 		hostname_abbreviation: DF.Data | None
 		ignore_incidents_since: DF.Datetime | None
 		instance_id: DF.Data | None
+		instance_ram: DF.Int
+		instance_type: DF.Data | None
 		ip: DF.Data | None
 		is_managed_database: DF.Check
 		is_primary: DF.Check
@@ -1351,7 +1353,9 @@ class Server(BaseServer):
 		use_for_build: DF.Check
 		use_for_new_benches: DF.Check
 		use_for_new_sites: DF.Check
+		vcpu: DF.Int
 		virtual_machine: DF.Link | None
+		volume_size: DF.Int
 	# end: auto-generated types
 
 	GUNICORN_MEMORY = 150  # avg ram usage of 1 gunicorn worker


### PR DESCRIPTION
Added an Instance Details section in the Server doctype which will be automatically populated after server creation.
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/f25a0ed4-5920-473e-b04a-2f3de7dfa243" />
