### PR TITLE
feat: Configuration Import

### DIFF
--- a/dashboard/src2/components/NewConfigImportDialog.vue
+++ b/dashboard/src2/components/NewConfigImportDialog.vue
@@ -5,6 +5,7 @@
 	>
 		<template v-slot:body-content>
 			<div class="space-y-4">
+				<!-- To do: Find a way to dynamically get the options -->
 				<FormControl
 					type="select"
 					label="Configuration Type"
@@ -15,6 +16,9 @@
 						'Buying Settings',
 						'Selling Settings',
 						'Stock Settings',
+						'Item Price Settings',
+						'HR Settings',
+						'Payroll Settings',
 						'System Settings'
 					]"
 					v-model="configType"
@@ -28,6 +32,12 @@
 					]"
 					v-model="sheetType"
 				/>
+				<p
+					v-if="sheetType === 'Google Sheets'"
+					class="text-xs text-gray-600"
+				>
+					Google Sheets must be shared with <code>{{ googleApiEmail }}</code> with <b>Viewer</b> access.
+				</p>
 				<FormControl
 					v-if="sheetType === 'Google Sheets'"
 					type="text"
@@ -74,7 +84,7 @@
 				:loading="$resources.newConfig.loading"
 				:loadingText="'Importing...'"
 				@click="$resources.newConfig.submit()"
-				:disabled="!configType || !sheetType || (sheetType === 'Google Sheets' && !googleSheetURL && googleSheetStatus !== 'Accessible') || (sheetType === 'Excel' && !excelFile)"
+				:disabled="!configType || !sheetType || (sheetType === 'Google Sheets' && !googleSheetURL || googleSheetStatus !== 'Accessible') || (sheetType === 'Excel' && !excelFile)"
 			>
 				Start Import
 			</Button>
@@ -98,6 +108,7 @@ export default {
 		ErrorMessage
 	},
 	data() {
+		// To do: Do not hardcode the googleApiEmail
 		return {
 			docResource: null,
 			showDialog: true,
@@ -107,6 +118,7 @@ export default {
 			googleSheetStatus: 'Not Tested',
 			googleSheetStatusMessage: null,
 			excelFile: null,
+			googleApiEmail: 'configuration-template@client-configuration-upload.iam.gserviceaccount.com',
 		};
 	},
 	resources: {
@@ -128,6 +140,7 @@ export default {
 				onSuccess() {
 					this.$emit('success');
 					this.showDialog = false;
+					window.location.reload();
 				},
 				onError(error) {
 					console.error(error);

--- a/dashboard/src2/components/NewConfigImportDialog.vue
+++ b/dashboard/src2/components/NewConfigImportDialog.vue
@@ -1,0 +1,168 @@
+<template>
+	<Dialog
+		:options="{ title: 'New Config Import' }"
+		v-model="showDialog"
+	>
+		<template v-slot:body-content>
+			<div class="space-y-4">
+				<FormControl
+					type="select"
+					label="Configuration Type"
+					:options="[
+						'Roles and Permissions',
+						'Field Properties',
+						'Accounts Settings',
+						'Buying Settings',
+						'Selling Settings',
+						'Stock Settings',
+						'System Settings'
+					]"
+					v-model="configType"
+				/>
+				<FormControl
+					type="select"
+					label="Sheet Type"
+					:options="[
+						'Google Sheets',
+						'Excel'
+					]"
+					v-model="sheetType"
+				/>
+				<FormControl
+					v-if="sheetType === 'Google Sheets'"
+					type="text"
+					label="Google Sheet URL"
+					v-model="googleSheetURL"
+					placeholder="https://docs.google.com/spreadsheets/"
+					autocomplete="off"
+				/>
+				<Button
+					v-if="sheetType === 'Google Sheets'"
+					@click="$resources.testGoogleSheetAccess.submit()"
+					:loading="$resources.testGoogleSheetAccess.loading"
+					:loadingText="'Testing...'"
+					variant="subtle"
+					class="w-full font-medium"
+					type="button"
+				>
+					Test Access
+				</Button>
+				<p
+					v-if="googleSheetStatusMessage"
+					class="text-xs text-gray-600"
+					:class="{
+						'text-green-600': googleSheetStatus === 'Accessible',
+						'text-red-600': googleSheetStatus === 'Inaccessible'
+					}"
+				>
+					{{ googleSheetStatusMessage }}
+				</p>
+				<FormControl
+					v-if="sheetType === 'Excel'"
+					type="file"
+					label="Excel File"
+					v-model="excelFile"
+					:accept="['.xlsx', '.xls']"
+					autocomplete="off"
+				/>
+			</div>
+		</template>
+		<template #actions>
+			<Button
+				class="mt-2 w-full"
+				variant="solid"
+				:loading="$resources.newConfig.loading"
+				:loadingText="'Importing...'"
+				@click="$resources.newConfig.submit()"
+				:disabled="!configType || !sheetType || (sheetType === 'Google Sheets' && !googleSheetURL && googleSheetStatus !== 'Accessible') || (sheetType === 'Excel' && !excelFile)"
+			>
+				Start Import
+			</Button>
+		</template>
+	</Dialog>
+</template>
+<script>
+import {
+	Autocomplete,
+	ErrorMessage,
+	FormControl,
+	getCachedDocumentResource
+} from 'frappe-ui';
+
+export default {
+	name: 'NewConfigImportDialog',
+	props: ['site', 'group', 'config'],
+	components: {
+		Autocomplete,
+		FormControl,
+		ErrorMessage
+	},
+	data() {
+		return {
+			docResource: null,
+			showDialog: true,
+			configType: null,
+			sheetType: null,
+			googleSheetURL: '',
+			googleSheetStatus: 'Not Tested',
+			googleSheetStatusMessage: null,
+			excelFile: null,
+		};
+	},
+	resources: {
+		newConfig() {
+			return {
+				url: 'press.api.site.new_config_import',
+				makeParams() {
+					return {
+						args: {
+							site: this.site,
+							configuration_type: this.configType,
+							sheet_type: this.sheetType,
+							google_sheet_url: this.googleSheetURL,
+							google_sheet_access_status: this.googleSheetStatus,
+							excel_file: this.excelFile,
+						}
+					};
+				},
+				onSuccess() {
+					this.$emit('success');
+					this.showDialog = false;
+				},
+				onError(error) {
+					console.error(error);
+				}
+			};
+		},
+		testGoogleSheetAccess() {
+			return {
+				url: 'press.api.site.test_google_sheet_permission',
+				makeParams() {
+					return {
+						sheet_type: this.sheetType,
+						google_sheet_url: this.googleSheetURL
+					};
+				},
+				onSuccess(result) {
+					const status = result;
+					this.googleSheetStatus = status;
+					if (status === 'Accessible') {
+						this.googleSheetStatusMessage =
+							'Google Sheet is accessible';
+					} else if (status === 'Inaccessible') {
+						this.googleSheetStatusMessage =
+							'Google Sheet is inaccessible. Please check if the URL is correct and the sheet is shared with the correct permissions.';
+					} else {
+						this.googleSheetStatusMessage = status;
+					}
+
+				},
+				onError(error) {
+					console.error(error);
+					this.googleSheetStatusMessage = error.message;
+				}
+			};
+		}
+	}
+};
+</script>

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1013,7 +1013,7 @@ export default {
 						return { site: site.doc?.name };
 					},
 					fields: ['name'],
-					pageLength: 999,
+					pageLength: 20,
 					orderBy: 'creation desc',
 					columns: [
 						{
@@ -1026,11 +1026,37 @@ export default {
 							fieldname: 'status',
 							width: 1,
 							type: 'Badge'
+							// To do: Add color coding
+							// Error - red
+							// Success - green
+							// Pending - yellow
+							// Partial Success - orange
 						},
 						{
 							label: 'Sheet Type',
 							fieldname: 'sheet_type',
 							width: 1
+						},
+						{
+							label: '',
+							fieldname: '',
+							align: 'right',
+							type: 'Button',
+							width: 1,
+							Button({ row }) {
+								const $team = getTeam();
+
+								return {
+									label: 'View Import Log',
+									slots: {
+										prefix: icon('eye')
+									},
+									condition: () => $team.doc?.is_desk_user || row.status !== 'Pending',
+									onClick() {
+										window.open(`/app/configuration-import/${row.name}`, '_blank');
+									}
+								}
+							}
 						}
 					],
 					primaryAction({ listResource: configs, documentResource: site }) {
@@ -1054,18 +1080,17 @@ export default {
 							}
 						};
 					},
-					rowActions({ row }) {
-						const $team = getTeam();
-				
-						return [
-							{
-								label: 'View in Desk',
-								condition: () => $team.doc?.is_desk_user,
-								onClick() {
-									window.open(`/app/configuration-import/${row.name}`, '_blank');
-								}
+					secondaryAction({ listResource: configs }) {
+						return {
+							label: 'View Import Templates',
+							slots: {
+								prefix: icon('external-link')
+							},
+							onClick() {
+								// To do: Do not hardcode this link
+								window.open(`https://drive.google.com/drive/u/0/folders/1-ICEigqvreWYB_16Jz6QDjiLznMKRc26/`, '_blank');
 							}
-						]
+						};
 					}
 				}
 			},

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1002,6 +1002,74 @@ export default {
 				}
 			},
 			{
+				label: 'Config Import',
+				icon: icon('upload'),
+				route: 'config-import',
+				type: 'list',
+				condition: site => site.doc?.status !== 'Archived',
+				list: {
+					doctype: 'Configuration Import',
+					filters: site => {
+						return { site: site.doc?.name };
+					},
+					fields: ['name'],
+					pageLength: 999,
+					orderBy: 'creation desc',
+					columns: [
+						{
+							label: 'Configuration Type',
+							fieldname: 'configuration_type',
+							width: 1
+						},
+						{
+							label: 'Status',
+							fieldname: 'status',
+							width: 1,
+							type: 'Badge'
+						},
+						{
+							label: 'Sheet Type',
+							fieldname: 'sheet_type',
+							width: 1
+						}
+					],
+					primaryAction({ listResource: configs, documentResource: site }) {
+						return {
+							label: 'New Import',
+							slots: {
+								prefix: icon('plus')
+							},
+							onClick() {
+								const NewConfigImportDialog = defineAsyncComponent(() =>
+									import('../components/NewConfigImportDialog.vue')
+								);
+								renderDialog(
+									h(NewConfigImportDialog, {
+										site: site.doc?.name,
+										onConfigAdded() {
+											configs.reload();
+										}
+									})
+								);
+							}
+						};
+					},
+					rowActions({ row }) {
+						const $team = getTeam();
+				
+						return [
+							{
+								label: 'View in Desk',
+								condition: () => $team.doc?.is_desk_user,
+								onClick() {
+									window.open(`/app/configuration-import/${row.name}`, '_blank');
+								}
+							}
+						]
+					}
+				}
+			},
+			{
 				label: 'Actions',
 				icon: icon('sliders'),
 				route: 'actions',

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1038,6 +1038,14 @@ export default {
 							width: 1
 						},
 						{
+							label: 'Date Created',
+							fieldname: 'creation',
+							width: 1,
+							format(value) {
+								return date(value, 'lll');
+							}
+						},
+						{
 							label: '',
 							fieldname: '',
 							align: 'right',

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -76,6 +76,7 @@ ALLOWED_DOCTYPES = [
 	"SQL Playground Log",
 	"Site Database User",
 	"Press Settings",
+	"Configuration Import",
 ]
 
 ALLOWED_DOCTYPES_FOR_SUPPORT = [

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -37,6 +37,7 @@ from press.utils import (
 	log_error,
 	unique,
 )
+from press.press.doctype.configuration_import.sheet_importer import get_sheet_importer
 
 if TYPE_CHECKING:
 	from frappe.types import DF
@@ -2353,3 +2354,27 @@ def get_site_config_standard_keys():
 		["name", "key", "title", "description", "type"],
 		order_by="title asc",
 	)
+
+@frappe.whitelist()
+def test_google_sheet_permission(sheet_type, google_sheet_url):
+	"""Test if the Google Sheet is accessible."""
+	if sheet_type != "Google Sheets" and not google_sheet_url:
+		return
+
+	try:
+		sheet_importer = get_sheet_importer("google", google_sheet_url)
+		status = "Accessible"
+	except:
+		status = "Inaccessible"
+
+	print(status)
+
+	return status
+
+@frappe.whitelist()
+def new_config_import(args):
+	doc = frappe.get_doc({
+		"doctype": "Configuration Import",
+		**args
+	})
+	doc.insert()

--- a/press/press/doctype/configuration_import/configuration_import.js
+++ b/press/press/doctype/configuration_import/configuration_import.js
@@ -6,15 +6,71 @@ frappe.ui.form.on("Configuration Import", {
         frm.trigger("update_primary_action");
 
         frm.has_import_file = () => {
-			return (frm.doc.sheet_type == "Google Sheets" && frm.doc.google_sheet_access_status == "Accessible") || (frm.doc.sheet_type == "Excel" && frm.doc.excel_file);
-		};
+            return (frm.doc.sheet_type == "Google Sheets" && frm.doc.google_sheet_access_status == "Accessible") || (frm.doc.sheet_type == "Excel" && frm.doc.excel_file);
+        };
     },
 
     onload_post_render(frm) {
-		frm.trigger("update_primary_action");
-	},
+        frm.trigger("update_primary_action");
+    },
 
-	test_permissions(frm) {
+    refresh(frm) {
+        frm.trigger("show_import_log");
+    },
+
+    show_failed_logs(frm) {
+        frm.trigger('show_import_log');
+    },
+
+    show_import_log(frm) { 
+        const import_log = JSON.parse(frm.doc.import_log || "[]");
+
+        let rows = import_log
+            .map((log) => {
+                let html = "";
+                let indicator_color = "red";
+                let title = __("Error");
+
+                if (log.status === "Success") {
+                    indicator_color = "green";
+                    title = __("Success");
+                }
+
+                if (frm.doc.show_failed_logs && log.status === "Success") {
+					return '';
+				}
+
+                return `<tr>
+                    <td>${log.row}</td>
+                    <td>
+                        <div class="indicator ${indicator_color}">${title}</div>
+                    </td>
+                    <td>
+                        ${log.message}
+                    </td>
+                </tr>`;
+            })
+            .join("");
+
+        if (!rows) {
+            rows = `<tr><td class="text-center text-muted" colspan=3>
+                ${__("No logs to show")}
+            </td></tr>`;
+        }
+
+        frm.get_field("import_log_preview").$wrapper.html(`
+            <table class="table table-bordered">
+                <tr class="text-muted">
+                    <th width="20%">${__("Row")}</th>
+                    <th width="20%">${__("Status")}</th>
+                    <th width="60%">${__("Message")}</th>
+                </tr>
+                ${rows}
+            </table>
+        `);
+    },
+
+    test_permissions(frm) {
         frm.call({
             method: "test_google_sheet_permission",
             freeze: true,
@@ -41,22 +97,29 @@ frappe.ui.form.on("Configuration Import", {
     },
 
     update_primary_action(frm) {
-		if (frm.is_dirty()) {
-			frm.enable_save();
-			return;
-		}
-		frm.disable_save();
-		if (frm.doc.status !== "Success") {
-			if (!frm.is_new() && frm.has_import_file()) {
-				let label = frm.doc.status === "Pending" ? __("Start Import") : __("Retry");
-				frm.page.set_primary_action(label, () => frm.events.start_import(frm));
-			} else {
-				frm.page.set_primary_action(__("Save"), () => frm.save());
-			}
-		}
-	},
+        if (frm.is_dirty()) {
+            frm.enable_save();
+            return;
+        }
+        frm.disable_save();
+        if (frm.doc.status !== "Success") {
+            if (!frm.is_new() && frm.has_import_file()) {
+                let label = frm.doc.status === "Pending" ? __("Start Import") : __("Retry");
+                frm.page.set_primary_action(label, () => frm.events.start_import(frm));
+            } else {
+                frm.page.set_primary_action(__("Save"), () => frm.save());
+            }
+        }
+    },
 
     start_import(frm) {
-        // import the configuration
+        frm.call({
+            method: "start_import",
+            doc: frm.doc,
+            callback: function(r) {
+                frm.disable_save();
+                frm.refresh();
+            }
+        });
     }
 });

--- a/press/press/doctype/configuration_import/configuration_import.js
+++ b/press/press/doctype/configuration_import/configuration_import.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2025, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Configuration Import", {
+    setup(frm) {
+        frm.trigger("update_primary_action");
+
+        frm.has_import_file = () => {
+			return (frm.doc.sheet_type == "Google Sheets" && frm.doc.google_sheet_access_status == "Accessible") || (frm.doc.sheet_type == "Excel" && frm.doc.excel_file);
+		};
+    },
+
+    onload_post_render(frm) {
+		frm.trigger("update_primary_action");
+	},
+
+	test_permissions(frm) {
+        frm.call({
+            method: "test_google_sheet_permission",
+            freeze: true,
+            freeze_message: "Testing Google Sheet access...",
+            doc: frm.doc,
+            callback: function(r) {
+                if (r.message) {
+                    frm.set_value("google_sheet_access_status", r.message);
+                }
+            }
+        });
+    },
+
+    google_sheet_url(frm) {
+        frm.set_value("google_sheet_access_status", "Not Tested");
+    },
+
+    google_sheet_access_status(frm) {
+        frm.trigger("update_primary_action");
+    },
+
+    excel_file(frm) {
+        frm.trigger("update_primary_action");
+    },
+
+    update_primary_action(frm) {
+		if (frm.is_dirty()) {
+			frm.enable_save();
+			return;
+		}
+		frm.disable_save();
+		if (frm.doc.status !== "Success") {
+			if (!frm.is_new() && frm.has_import_file()) {
+				let label = frm.doc.status === "Pending" ? __("Start Import") : __("Retry");
+				frm.page.set_primary_action(label, () => frm.events.start_import(frm));
+			} else {
+				frm.page.set_primary_action(__("Save"), () => frm.save());
+			}
+		}
+	},
+
+    start_import(frm) {
+        // import the configuration
+    }
+});

--- a/press/press/doctype/configuration_import/configuration_import.json
+++ b/press/press/doctype/configuration_import/configuration_import.json
@@ -20,13 +20,15 @@
   "import_preview",
   "import_log_section",
   "show_failed_logs",
-  "import_log_preview"
+  "import_log_preview",
+  "import_log"
  ],
  "fields": [
   {
    "fieldname": "status",
    "fieldtype": "Select",
    "hidden": 1,
+   "in_list_view": 1,
    "label": "Status",
    "no_copy": 1,
    "options": "Pending\nIn Progress\nSuccess\nPartial Success\nError"
@@ -44,7 +46,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Configuration Type",
-   "options": "\nRoles and Permissions\nField Properties\nAccounts Settings\nBuying Settings\nSelling Settings\nStock Settings\nSystem Settings",
+   "options": "\nRoles and Permissions\nField Properties\nAccounts Settings\nBuying Settings\nSelling Settings\nStock Settings\nItem Price Settings\nHR Settings\nPayroll Settings\nSystem Settings",
    "reqd": 1,
    "set_only_once": 1
   },
@@ -88,6 +90,7 @@
   {
    "fieldname": "import_file_errors_and_warnings_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Import File Errors and Warnings"
   },
   {
@@ -105,6 +108,7 @@
   {
    "fieldname": "preview_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Preview"
   },
   {
@@ -127,13 +131,20 @@
    "fieldname": "import_log_preview",
    "fieldtype": "HTML",
    "label": "Import Log Preview"
+  },
+  {
+   "fieldname": "import_log",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Import Log",
+   "options": "JSON"
   }
  ],
  "grid_page_length": 50,
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-04 17:44:40.500482",
+ "modified": "2025-05-15 18:35:42.223809",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Configuration Import",

--- a/press/press/doctype/configuration_import/configuration_import.json
+++ b/press/press/doctype/configuration_import/configuration_import.json
@@ -133,7 +133,7 @@
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-03 20:30:10.250740",
+ "modified": "2025-04-04 17:44:40.500482",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Configuration Import",
@@ -161,6 +161,18 @@
    "read": 1,
    "report": 1,
    "role": "Press Member",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Admin",
    "share": 1,
    "write": 1
   }

--- a/press/press/doctype/configuration_import/configuration_import.json
+++ b/press/press/doctype/configuration_import/configuration_import.json
@@ -1,0 +1,172 @@
+{
+ "actions": [],
+ "autoname": "format:{site} {configuration_type} Import on {creation}",
+ "creation": "2025-04-03 17:22:03.165241",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "status",
+  "site",
+  "configuration_type",
+  "sheet_type",
+  "google_sheet_url",
+  "test_permissions",
+  "google_sheet_access_status",
+  "excel_file",
+  "import_file_errors_and_warnings_section",
+  "template_warnings",
+  "import_warnings",
+  "preview_section",
+  "import_preview",
+  "import_log_section",
+  "show_failed_logs",
+  "import_log_preview"
+ ],
+ "fields": [
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Pending\nIn Progress\nSuccess\nPartial Success\nError"
+  },
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Site",
+   "options": "Site",
+   "reqd": 1
+  },
+  {
+   "fieldname": "configuration_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Configuration Type",
+   "options": "\nRoles and Permissions\nField Properties\nAccounts Settings\nBuying Settings\nSelling Settings\nStock Settings\nSystem Settings",
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal;",
+   "fieldname": "sheet_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Sheet Type",
+   "mandatory_depends_on": "eval:!doc.__islocal;",
+   "options": "\nGoogle Sheets\nExcel"
+  },
+  {
+   "depends_on": "eval:doc.sheet_type==\"Google Sheets\";",
+   "fieldname": "google_sheet_url",
+   "fieldtype": "Data",
+   "label": "Google Sheet URL",
+   "mandatory_depends_on": "eval:doc.sheet_type==\"Google Sheets\";"
+  },
+  {
+   "depends_on": "eval:doc.sheet_type==\"Google Sheets\";",
+   "fieldname": "test_permissions",
+   "fieldtype": "Button",
+   "label": "Test Permissions"
+  },
+  {
+   "default": "Not Tested",
+   "depends_on": "eval:doc.sheet_type==\"Google Sheets\";",
+   "fieldname": "google_sheet_access_status",
+   "fieldtype": "Select",
+   "label": "Google Sheet Access Status",
+   "options": "Not Tested\nAccessible\nInaccessible",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.sheet_type==\"Excel\";",
+   "fieldname": "excel_file",
+   "fieldtype": "Attach",
+   "label": "Excel File"
+  },
+  {
+   "fieldname": "import_file_errors_and_warnings_section",
+   "fieldtype": "Section Break",
+   "label": "Import File Errors and Warnings"
+  },
+  {
+   "fieldname": "template_warnings",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Template Warnings",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "import_warnings",
+   "fieldtype": "HTML",
+   "label": "Import Warnings"
+  },
+  {
+   "fieldname": "preview_section",
+   "fieldtype": "Section Break",
+   "label": "Preview"
+  },
+  {
+   "fieldname": "import_preview",
+   "fieldtype": "HTML",
+   "label": "Import Preview"
+  },
+  {
+   "fieldname": "import_log_section",
+   "fieldtype": "Section Break",
+   "label": "Import Log"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_failed_logs",
+   "fieldtype": "Check",
+   "label": "Show Only Failed Logs"
+  },
+  {
+   "fieldname": "import_log_preview",
+   "fieldtype": "HTML",
+   "label": "Import Log Preview"
+  }
+ ],
+ "grid_page_length": 50,
+ "hide_toolbar": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-03 20:30:10.250740",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Configuration Import",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Member",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/press/press/doctype/configuration_import/configuration_import.py
+++ b/press/press/doctype/configuration_import/configuration_import.py
@@ -32,7 +32,7 @@ class ConfigurationImport(Document):
 		template_warnings: DF.Code | None
 	# end: auto-generated types
 
-	dashboard_fields = ["site", "configuration_type", "sheet_type", "status"]
+	dashboard_fields = ["site", "configuration_type", "sheet_type", "status", "creation"]
 
 	def after_insert(self):
 		if self.status == "Pending":

--- a/press/press/doctype/configuration_import/configuration_import.py
+++ b/press/press/doctype/configuration_import/configuration_import.py
@@ -2,9 +2,12 @@
 # For license information, please see license.txt
 
 import frappe
+import paramiko
+import os
+import re
+import json
 from frappe.model.document import Document
 
-from press.api.client import dashboard_whitelist
 from .sheet_importer import get_sheet_importer
 
 
@@ -17,10 +20,11 @@ class ConfigurationImport(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		configuration_type: DF.Literal["", "Roles and Permissions", "Field Properties", "Accounts Settings", "Buying Settings", "Selling Settings", "Stock Settings", "System Settings"]
+		configuration_type: DF.Literal["", "Roles and Permissions", "Field Properties", "Accounts Settings", "Buying Settings", "Selling Settings", "Stock Settings", "Item Price Settings", "HR Settings", "Payroll Settings", "System Settings"]
 		excel_file: DF.Attach | None
 		google_sheet_access_status: DF.Literal["Not Tested", "Accessible", "Inaccessible"]
 		google_sheet_url: DF.Data | None
+		import_log: DF.Code | None
 		sheet_type: DF.Literal["", "Google Sheets", "Excel"]
 		show_failed_logs: DF.Check
 		site: DF.Link
@@ -28,7 +32,47 @@ class ConfigurationImport(Document):
 		template_warnings: DF.Code | None
 	# end: auto-generated types
 
-	dashboard_fields = ["configuration_type", "sheet_type", "status"]
+	dashboard_fields = ["site", "configuration_type", "sheet_type", "status"]
+
+	def after_insert(self):
+		if self.status == "Pending":
+			self.start_import()
+
+	def setup_remote_connection(self):
+		site = frappe.get_doc("Site", self.site)
+		server = frappe.get_doc("Server", site.server)
+		server_ip = server.ip
+		server_port = server.ssh_port or 22
+		server_username = server.ssh_user or "ubuntu"
+
+		try:
+			pkey = paramiko.RSAKey.from_private_key_file(get_ssh_key())
+			self.client = paramiko.SSHClient()
+			self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+			self.client.connect(server_ip, port=server_port, username=server_username, pkey=pkey)
+		except Exception as e:
+			self.fail = True
+			self.client = 0
+			print("Site Setup Error: Failed to connect to server", data=e)
+
+	def close_remote_connection(self):
+		if self.client:
+			self.client.close()
+
+	def execute_commands(self, commands):
+		output = {"message": "", "exit_status": 0}
+		traceback = ""
+
+		for command in commands:
+			_stdin, stdout, stderr = self.client.exec_command(command)
+			output["message"] += stdout.read().decode()
+			traceback += stderr.read().decode()
+			exit_status = stdout.channel.recv_exit_status()
+			if exit_status != 0:
+				output["exit_status"] = exit_status
+				break
+
+		return output, traceback
 	
 	@frappe.whitelist()
 	def test_google_sheet_permission(self):
@@ -43,3 +87,126 @@ class ConfigurationImport(Document):
 			status = "Inaccessible"
 
 		return status
+	 
+	@frappe.whitelist()
+	def start_import(self):
+		"""Queue the import process."""
+		frappe.enqueue_doc(
+			self.doctype, self.name, "_start_import", queue="short", timeout=300
+		)
+		
+	def _start_import(self):
+		"""Import configuration from the selected sheet."""
+
+		self.setup_remote_connection()
+		
+		import_functions_map = {
+			"Roles and Permissions": "import-role-permissions",
+			"Field Properties": "import-custom-properties",
+			"Accounts Settings": "import-settings",
+			"Buying Settings": "import-settings",
+			"Selling Settings": "import-settings",
+			"Stock Settings": "import-settings",
+			"System Settings": "import-settings",
+			"HR Settings": "import-settings",
+			"Payroll Settings": "import-settings",
+			"Item Price Settings": "import-settings"
+		}
+
+		frappe_bench_dir = "/home/ubuntu/frappe-bench"
+		bench_path = "/home/ubuntu/.local/bin/bench"
+
+		sheet_type = self.sheet_type.lower() if self.sheet_type == "Excel" else "google"
+		sheet_location = self.google_sheet_url if self.sheet_type == "Google Sheets" else self.excel_file
+
+		commands = [
+			f'source ~/.profile && (cd {frappe_bench_dir} && {bench_path} {import_functions_map[self.configuration_type]} --sheet-type {sheet_type} --sheet-location {sheet_location})',
+		]
+
+		if self.configuration_type == "Field Properties":
+			commands.append(f'source ~/.profile && (cd {frappe_bench_dir} && {bench_path} clear-cache)')
+
+		output, traceback = self.execute_commands(commands)
+
+		self.close_remote_connection()
+
+		parsed_logs = parse_and_group_entries(output["message"].split("\n"))
+		self.import_log = json.dumps(parsed_logs, indent=2)
+
+		if evaluate_status_distribution(parsed_logs) == "all error" or output["exit_status"] != 0:
+			self.status = "Error"
+		elif evaluate_status_distribution(parsed_logs) == "all success":
+			self.status = "Success"
+		elif evaluate_status_distribution(parsed_logs) == "mixed":
+			self.status = "Partial Success"
+		
+		self.save()
+
+		frappe.logger().error(traceback)
+
+		frappe.msgprint("Import completed successfully." if self.status == "Success" else "Import failed. Please check the logs for more details.")
+
+
+def get_ssh_key():
+	ssh_key = frappe.db.get_single_value('Press Settings', 'default_ssh_key')
+	file_path = os.path.join(frappe.utils.get_site_path(), ssh_key.lstrip("/"))
+
+	return file_path
+
+
+# Regex to match ANSI escape sequences like \033[92m
+ANSI_ESCAPE = re.compile(r'\x1B\[[0-9;]*[A-Za-z]')
+
+def strip_ansi_codes(text):
+    return ANSI_ESCAPE.sub('', text)
+
+
+def parse_log_entry(log_entry):
+	clean_entry = strip_ansi_codes(log_entry)
+	pattern = r"\[(Row|DocType|File) ([^\]]+)\]\[(\w+)\] (.+)"
+	match = re.match(pattern, clean_entry)
+	if match:
+		entity_type = match.group(1)
+		row_number = match.group(2)
+		status = match.group(3)
+		message = match.group(4)
+		return {
+			"entity_type": entity_type,
+			"row": row_number,
+			"status": status,
+			"message": message
+		}
+	else:
+		raise ValueError(f"Invalid log entry format: {clean_entry}")
+
+
+def parse_and_group_entries(log_entries):
+	grouped = {}
+	for entry in log_entries:
+		try:
+			parsed = parse_log_entry(entry)
+			key = parsed["message"]
+			if key not in grouped:
+				grouped[key] = {
+					"entity_type": parsed["entity_type"],
+					"row": parsed["row"],
+					"status": parsed["status"],
+					"message": parsed["message"]
+				}
+			else:
+				grouped[key]["row"] += f", {str(parsed['row'])}"
+		except ValueError as e:
+			print(e)
+			continue
+	return list(grouped.values())
+
+
+def evaluate_status_distribution(entries):
+	statuses = set(entry["status"].lower() for entry in entries)
+
+	if statuses == {"success"}:
+		return "all success"
+	elif statuses == {"error"}:
+		return "all error"
+	else:
+		return "mixed"

--- a/press/press/doctype/configuration_import/configuration_import.py
+++ b/press/press/doctype/configuration_import/configuration_import.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+from .sheet_importer import get_sheet_importer
+
+
+class ConfigurationImport(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		configuration_type: DF.Literal["", "Roles and Permissions", "Field Properties", "Accounts Settings", "Buying Settings", "Selling Settings", "Stock Settings", "System Settings"]
+		excel_file: DF.Attach | None
+		google_sheet_access_status: DF.Literal["Not Tested", "Accessible", "Inaccessible"]
+		google_sheet_url: DF.Data | None
+		sheet_type: DF.Literal["", "Google Sheets", "Excel"]
+		show_failed_logs: DF.Check
+		site: DF.Link
+		status: DF.Literal["Pending", "In Progress", "Success", "Partial Success", "Error"]
+		template_warnings: DF.Code | None
+	# end: auto-generated types
+	
+	@frappe.whitelist()
+	def test_google_sheet_permission(self):
+		"""Test if the Google Sheet is accessible."""
+		if self.sheet_type != "Google Sheets" and not self.google_sheet_url:
+			return
+
+		try:
+			sheet_importer = get_sheet_importer("google", self.google_sheet_url)
+			status = "Accessible"
+		except:
+			status = "Inaccessible"
+
+		return status

--- a/press/press/doctype/configuration_import/configuration_import.py
+++ b/press/press/doctype/configuration_import/configuration_import.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.model.document import Document
 
+from press.api.client import dashboard_whitelist
 from .sheet_importer import get_sheet_importer
 
 
@@ -26,6 +27,8 @@ class ConfigurationImport(Document):
 		status: DF.Literal["Pending", "In Progress", "Success", "Partial Success", "Error"]
 		template_warnings: DF.Code | None
 	# end: auto-generated types
+
+	dashboard_fields = ["configuration_type", "sheet_type", "status"]
 	
 	@frappe.whitelist()
 	def test_google_sheet_permission(self):

--- a/press/press/doctype/configuration_import/sheet_importer.py
+++ b/press/press/doctype/configuration_import/sheet_importer.py
@@ -1,0 +1,98 @@
+import os
+import frappe
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+from abc import ABC, abstractmethod
+from gspread.exceptions import WorksheetNotFound
+from json.decoder import JSONDecodeError
+
+
+JSON_KEYFILE = os.path.abspath(frappe.get_site_path("google_keyfile.json"))
+SCOPES = [
+    "https://spreadsheets.google.com/feeds",
+    "https://www.googleapis.com/auth/drive",
+]
+SETTINGS_LIST = [
+    "Accounts Settings",
+    "Buying Settings",
+    "Selling Settings",
+    "Stock Settings",
+    "System Settings",
+    "Item Price Settings",
+]
+WORKSHEETS = [
+    "New Fields",
+    "Field Properties",
+    "Roles and Permissions",
+    *SETTINGS_LIST,
+]
+
+
+class JSONKeyFileError(Exception):
+    pass
+
+
+class SheetImporter(ABC):
+    @abstractmethod
+    def get_worksheet(self, sheet_name):
+        pass
+
+    @abstractmethod
+    def get_worksheet_data(self, sheet_name, as_list=False):
+        pass
+
+
+class GoogleSheetImporter(SheetImporter):
+    def __init__(self, workbook_url):
+        self.initialize_client()
+        self.set_workbook(workbook_url)
+
+    def initialize_client(self):
+        try:
+            creds = ServiceAccountCredentials.from_json_keyfile_name(
+                JSON_KEYFILE, SCOPES
+            )
+        except JSONDecodeError:
+            raise JSONKeyFileError(
+                "Please ensure that the Google API credentials have been correctly pasted in the file google_keyfile.json and are in a valid JSON format."
+            )
+        else:
+            self.client = gspread.authorize(creds)
+
+    def set_workbook(self, workbook_url):
+        if workbook_url.startswith("https://docs.google.com/spreadsheets"):
+            self.workbook = self.client.open_by_url(workbook_url)
+        else:
+            raise ValueError("URL must be a Google Sheet URL")
+
+    def get_worksheet(self, sheet_name):
+        try:
+            worksheet = self.workbook.worksheet(sheet_name)
+        except WorksheetNotFound:
+            error_msg = "Worksheet name must be one of the following: " + ", ".join(
+                WORKSHEETS
+            )
+            raise ValueError(error_msg)
+        else:
+            return worksheet
+
+    def get_worksheet_data(self, sheet_name, as_list=False):
+        """
+        Returns a list of dictionaries by default. Each dictionary represents a row in the sheet.
+        If as_list is True, returns a list of lists.
+        """
+        worksheet = self.get_worksheet(sheet_name)
+        if as_list:
+            data = worksheet.get_values()
+        else:
+            data = worksheet.get_all_records()
+
+        return data
+
+
+def get_sheet_importer(sheet_type, sheet_location):
+    sheet_type = sheet_type.lower()
+    if sheet_type == "google":
+        return GoogleSheetImporter(sheet_location)
+    elif sheet_type == "excel":
+        return

--- a/press/press/doctype/configuration_import/sheet_importer.py
+++ b/press/press/doctype/configuration_import/sheet_importer.py
@@ -7,7 +7,6 @@ from gspread.exceptions import WorksheetNotFound
 from json.decoder import JSONDecodeError
 
 
-JSON_KEYFILE = os.path.abspath(frappe.get_site_path("google_keyfile.json"))
 SCOPES = [
     "https://spreadsheets.google.com/feeds",
     "https://www.googleapis.com/auth/drive",
@@ -18,6 +17,8 @@ SETTINGS_LIST = [
     "Selling Settings",
     "Stock Settings",
     "System Settings",
+    "HR Settings",
+    "Payroll Settings",
     "Item Price Settings",
 ]
 WORKSHEETS = [
@@ -48,6 +49,8 @@ class GoogleSheetImporter(SheetImporter):
         self.set_workbook(workbook_url)
 
     def initialize_client(self):
+        JSON_KEYFILE = os.path.abspath(frappe.utils.get_site_path("google_keyfile.json"))
+
         try:
             creds = ServiceAccountCredentials.from_json_keyfile_name(
                 JSON_KEYFILE, SCOPES

--- a/press/press/doctype/configuration_import/test_configuration_import.py
+++ b/press/press/doctype/configuration_import/test_configuration_import.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestConfigurationImport(FrappeTestCase):
+	pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ twilio==8.10.3
 wrapt~=1.15.0
 elasticsearch-dsl>=8.0.0,<9.0.0
 hcloud==2.2.1
+gspread
+oauth2client


### PR DESCRIPTION
This PR introduces a new Configuration Import tab to the Site dashboard, enabling easier management of the following site-specific configuration imports:
1. Roles and Permissions
2. Field Properties
3. Accounts Settings
4. Buying Settings
5. Selling Settings
6. Stock Settings
7. Item Price Settings
8. HR Settings
9. Payroll Settings
10. System Settings
<img width="1775" alt="image" src="https://github.com/user-attachments/assets/4369a54a-f2c5-441d-894e-e6b30e05648f" />
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/cb86e100-41f1-48aa-9020-d1a3c6cf0eab" />
