### PR TITLE
feat: Automatic Updates

### DIFF
--- a/dashboard/src2/components/site/AutoUpdateSettings.vue
+++ b/dashboard/src2/components/site/AutoUpdateSettings.vue
@@ -1,0 +1,233 @@
+<template>
+	<div>
+		<div class="flex p-5 gap-7.5">
+			<Switch
+				class="mr-8"
+				label="Enable Automatic Updates"
+				description="If unchecked, this site will not receive automatic updates which include new features and bug fixes."
+				v-model="enableUpdates"
+				@click="isDirty = true"
+			/>
+			<FormControl
+				v-if="enableUpdates"
+				label="Update Trigger Frequency"
+				type="select"
+				v-model="updateFrequency"
+				:disabled="!enableUpdates"
+				:options="[
+					'Daily',
+					'Weekly',
+					'Every 2 Weeks'
+				]"
+				@change="isDirty = true"
+			/>
+			<FormControl
+				v-if="enableUpdates && updateFrequency === 'Every 2 Weeks'"
+				label="Update Start Date"
+				type="date"
+				v-model="updateStartDate"
+				:disabled="!enableUpdates"
+				@change="isDirty = true"
+			/>
+			<FormControl
+				v-if="enableUpdates && updateFrequency !== 'Daily'"
+				label="Update Trigger Day"
+				type="select"
+				v-model="updateDay"
+				:disabled="!enableUpdates"
+				:options="[
+					'Monday',
+					'Tuesday',
+					'Wednesday',
+					'Thursday'
+				]"
+				@change="isDirty = true"
+			/>
+			<FormControl
+				v-if="enableUpdates"
+				label="Update Trigger Time"
+				type="time"
+				v-model="updateTriggerTime"
+				:disabled="!enableUpdates"
+				@change="isDirty = true"
+			/>
+			<Button
+				size="sm"
+				class="my-5"
+				variant="solid"
+				:label="isDirty ? 'Save' : 'Saved'"
+				@click="siteResource.setValue.submit(
+					{ 
+						skip_auto_updates: !enableUpdates,
+						update_trigger_frequency: updateFrequency,
+						update_on_weekday: updateDay,
+						update_trigger_time: updateTriggerTime
+					},
+					{
+						onSuccess() {
+							toast.success('Auto Update settings updated successfully.');
+							isDirty = false;
+						},
+						onError() {
+							toast.error('Failed to update Auto Update settings.');
+							setTimeout(() => window.location.reload(), 1000);
+						},
+					},
+				)"
+				:loading="siteResource.setValue.loading"
+				loadingText="Saving"
+				:disabled="!isDirty"
+			/>
+		</div>
+		<ObjectList class="pl-5" :options="logsOptions" />
+	</div>
+</template>
+
+<script setup>
+
+import { 
+	createResource,
+	createDocumentResource,
+} from 'frappe-ui';
+import { toast } from 'vue-sonner';
+import { computed, ref, toRefs } from 'vue';
+import { confirmDialog, icon } from '../../utils/components';
+import { duration } from '../../utils/format';
+import ObjectList from '../ObjectList.vue';
+import router from '../../router';
+
+const props = defineProps({
+	site: {
+		type: String,
+		required: true
+	}
+});
+
+const isDirty = ref(false);
+
+const siteResource = createDocumentResource({
+	doctype: 'Site',
+	name: props.site,
+	auto: true,
+});
+
+const siteValues = computed(() => {
+	if (!siteResource.doc) return {};
+	return {
+		enableUpdates: !siteResource.doc.skip_auto_updates,
+		updateFrequency: siteResource.doc.update_trigger_frequency,
+		updateDay: siteResource.doc.update_on_weekday,
+		updateTriggerTime: siteResource.doc.update_trigger_time
+	};
+});
+
+const enableUpdates = ref(siteValues.value?.enableUpdates);
+const updateFrequency = ref(siteValues.value?.updateFrequency);
+const updateStartDate = ref(null);
+const updateDay = ref(siteValues.value?.updateDay);
+const updateTriggerTime = ref(siteValues.value?.updateTriggerTime);
+
+const logsResource = createResource({
+	url: 'press.api.client.get_list',
+	params: {
+		doctype: 'Agent Job',
+		filters: {
+			site: props.site,
+			job_type: 'Update Site'
+		},
+		order_by: 'creation desc',
+		fields: ['name', 'end', 'job_id', 'job_type', 'status', 'duration', 'owner', 'creation'],
+	},
+	initialData: [],
+	auto: true
+});
+
+const logsOptions = computed(() => ({
+	data: () => logsResource.data,
+	columns: [
+		{
+			label: 'Job Type',
+			fieldname: 'job_type',
+			class: 'font-medium'
+		},
+		{
+			label: 'Status',
+			fieldname: 'status',
+			type: 'Badge',
+			width: 0.5
+		},
+		{
+			label: 'Duration',
+			fieldname: 'duration',
+			width: 0.35,
+			format(value, row) {
+				if (!row.end) return;
+				return duration(value);
+			}
+		},
+		{
+			label: 'Created By',
+			fieldname: 'owner'
+		},
+		{
+			label: '',
+			fieldname: 'creation',
+			type: 'Timestamp',
+			width: 0.5,
+			align: 'right'
+		}
+	],
+	primaryAction({ listResource }) {
+		return {
+			label: 'Get Updates',
+			slots: {
+				prefix: icon('arrow-up-circle')
+			},
+			onClick() {
+				confirmDialog({
+					title: 'Get Updates',
+					message:
+						'Are you sure you want to update the site? This will apply the latest changes and may take some time.',
+					onSuccess({ hide }) {
+						toast.promise(
+							siteResource.updateSite.submit(),
+							{
+								loading: 'Scheduling site update...',
+								success: () => {
+									hide();
+									return 'Site update scheduled successfully.';
+								},
+								error: e => getToastErrorMessage(e)
+							}
+						);
+					}
+				});
+			}
+		};
+	},
+	secondaryAction() {
+		return {
+			label: 'Refresh',
+			icon: 'refresh-ccw',
+			onClick: () => logsResource.reload()
+		};
+	},
+	rowActions({ row, listResource: configs, documentResource: site }) {
+		return [
+			{
+				label: 'View Log',
+				onClick() {
+					router.push({
+						name: 'Site Job',
+						params: {
+							name: props.site,
+							id: row.name
+						}
+					});
+				}
+			}
+		];
+	}
+}));
+
+</script>

--- a/dashboard/src2/components/site/AutoUpdateSettings.vue
+++ b/dashboard/src2/components/site/AutoUpdateSettings.vue
@@ -60,6 +60,7 @@
 					{ 
 						skip_auto_updates: !enableUpdates,
 						update_trigger_frequency: updateFrequency,
+						update_start_date: updateStartDate,
 						update_on_weekday: updateDay,
 						update_trigger_time: updateTriggerTime
 					},
@@ -116,6 +117,7 @@ const siteValues = computed(() => {
 	return {
 		enableUpdates: !siteResource.doc.skip_auto_updates,
 		updateFrequency: siteResource.doc.update_trigger_frequency,
+		updateStartDate: siteResource.doc.update_start_date,
 		updateDay: siteResource.doc.update_on_weekday,
 		updateTriggerTime: siteResource.doc.update_trigger_time
 	};
@@ -123,7 +125,7 @@ const siteValues = computed(() => {
 
 const enableUpdates = ref(siteValues.value?.enableUpdates);
 const updateFrequency = ref(siteValues.value?.updateFrequency);
-const updateStartDate = ref(null);
+const updateStartDate = ref(siteValues.value?.updateStartDate);
 const updateDay = ref(siteValues.value?.updateDay);
 const updateTriggerTime = ref(siteValues.value?.updateTriggerTime);
 

--- a/dashboard/src2/components/site/AutoUpdateSettings.vue
+++ b/dashboard/src2/components/site/AutoUpdateSettings.vue
@@ -9,7 +9,7 @@
 				@click="isDirty = true"
 			/>
 			<FormControl
-				v-if="enableUpdates"
+				v-if="enableUpdates && domain === 'prod'"
 				label="Update Trigger Frequency"
 				type="select"
 				v-model="updateFrequency"
@@ -22,7 +22,7 @@
 				@change="isDirty = true"
 			/>
 			<FormControl
-				v-if="enableUpdates && updateFrequency === 'Every 2 Weeks'"
+				v-if="enableUpdates && domain === 'prod' && updateFrequency === 'Every 2 Weeks'"
 				label="Update Start Date"
 				type="date"
 				v-model="updateStartDate"
@@ -30,7 +30,7 @@
 				@change="isDirty = true"
 			/>
 			<FormControl
-				v-if="enableUpdates && updateFrequency !== 'Daily'"
+				v-if="enableUpdates && domain === 'prod' && updateFrequency !== 'Daily'"
 				label="Update Trigger Day"
 				type="select"
 				v-model="updateDay"
@@ -44,7 +44,7 @@
 				@change="isDirty = true"
 			/>
 			<FormControl
-				v-if="enableUpdates"
+				v-if="enableUpdates && domain === 'prod'"
 				label="Update Trigger Time"
 				type="time"
 				v-model="updateTriggerTime"
@@ -119,7 +119,8 @@ const siteValues = computed(() => {
 		updateFrequency: siteResource.doc.update_trigger_frequency,
 		updateStartDate: siteResource.doc.update_start_date,
 		updateDay: siteResource.doc.update_on_weekday,
-		updateTriggerTime: siteResource.doc.update_trigger_time
+		updateTriggerTime: siteResource.doc.update_trigger_time,
+		domain: siteResource.doc.domain
 	};
 });
 
@@ -128,6 +129,7 @@ const updateFrequency = ref(siteValues.value?.updateFrequency);
 const updateStartDate = ref(siteValues.value?.updateStartDate);
 const updateDay = ref(siteValues.value?.updateDay);
 const updateTriggerTime = ref(siteValues.value?.updateTriggerTime);
+const domain = ref(siteValues.value?.domain);
 
 const logsResource = createResource({
 	url: 'press.api.client.get_list',
@@ -189,7 +191,7 @@ const logsOptions = computed(() => ({
 				confirmDialog({
 					title: 'Get Updates',
 					message:
-						'Are you sure you want to update the site? This will apply the latest changes and may take some time.',
+						'This will immediately apply the latest changes and may take some time. Are you sure you want to update the site?',
 					onSuccess({ hide }) {
 						toast.promise(
 							siteResource.updateSite.submit(),

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -266,6 +266,7 @@ scheduler_events = {
 			"press.press.doctype.site_replication.site_replication.update_from_site",
 			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_snapshots",
 			"press.press.doctype.site.site.sync_sites_setup_wizard_complete_status",
+			"press.press.doctype.site.site.auto_update_all_sites",
 		],
 		"* * * * *": [
 			"press.press.doctype.deploy_candidate.deploy_candidate.run_scheduled_builds",

--- a/press/press/doctype/site/bizkit_site_update.py
+++ b/press/press/doctype/site/bizkit_site_update.py
@@ -1,0 +1,281 @@
+import os
+import json
+import paramiko
+from datetime import datetime, timedelta
+import boto3
+from urllib.parse import urlparse, unquote
+
+import frappe
+from frappe.utils import now_datetime as now
+from press.utils import log_error
+
+
+MAX_DURATION = timedelta(hours=23, minutes=59, seconds=59)
+ENV_ABBR = {
+    "Development": "dev",
+    "Production": "prod",
+    "Demo": "demo",
+}
+
+
+class SiteUpdate:
+    def __init__(self, site, verbose=False):
+        self.site = site
+        self.server_name = self.site.server
+        self.bench = self.site.bench
+        self.verbose = verbose
+        self.get_app_server_details()
+        self.set_bench_path()
+        self.fail = False
+
+    def get_app_server_details(self):
+        server_doc = frappe.get_doc("Server", self.server_name)
+        self.server_ip = server_doc.ip
+        self.server_username = server_doc.ssh_user
+        self.server_port = server_doc.ssh_port or 22
+        self.environment = server_doc.environment
+        self.server_abbr = server_doc.hostname_abbreviation.replace("-", "_")
+
+    def execute(self):
+        frappe.msgprint("Site update started.")
+        self.create_agent_job_type()
+        self.create_agent_job()
+        self.setup_remote_connection()
+        
+        if self.client:
+            self.enable_maintenance_mode()
+            self.pull_changes()
+            self.bench_build()
+            self.bench_migrate()
+            self.bench_restart()
+            self.disable_maintenance_mode()
+        
+        self.update_agent_job_status()
+        self.close_remote_connection()
+        self.update_site_status()
+        frappe.msgprint("Site update completed. Please check the Agent Job for more details.")
+
+    def update_site_status(self):
+        self.site.reload()
+        if self.fail:
+            self.site.status = "Broken"
+        else:
+            self.site.status = "Active"
+            self.site.setup_wizard_complete = 1
+        self.site.save()
+        frappe.db.commit()
+
+    def create_agent_job_type(self):
+        if frappe.db.exists("Agent Job Type", "Update Site"):
+            return
+
+        doc = frappe.get_doc({
+            "doctype": "Agent Job Type",
+            "name": "Update Site",
+            "request_method": None,
+            "request_path": None,
+            "steps": [
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Enable Maintenance Mode"
+                },
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Pull Changes"
+                },
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Bench Build"
+                },
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Bench Migrate"
+                },
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Bench Restart"
+                },
+                {
+                    "parent": "Update Site",
+                    "parentfield": "steps",
+                    "parenttype": "Agent Job Type",
+                    "step_name": "Disable Maintenance Mode"
+                },
+            ],
+            "disabled_auto_retry": 1,
+        })
+        doc.insert()
+        frappe.db.commit()
+
+    def create_agent_job(self):
+        self.start_time = now()
+        self.agent_job = frappe.get_doc({
+            "doctype": "Agent Job",
+            "job_type": "Update Site",
+            "server_type": "Server",
+            "server": self.server_name,
+            "start": self.start_time,
+            "status": "Running",
+            "request_method": "POST",
+            "request_path": "None",
+            "request_data": json.dumps({}),
+            "request_files": json.dumps({}),
+            "output": "",
+            "traceback": "",
+            "site": self.site.name,
+            "bench": self.bench,
+        })
+        self.agent_job.insert()
+        frappe.db.commit()
+
+    def update_agent_job_status(self):
+        self.agent_job.reload()
+        self.agent_job.status = "Failure" if self.fail else "Success"
+        self.agent_job.end = now()
+        self.agent_job.duration = min(self.agent_job.end - self.start_time, MAX_DURATION)
+        self.agent_job.save()
+        frappe.db.commit()
+
+    def update_agent_job_step(self, step, start_time, output=None, traceback=None, skipped=False):
+        doc = frappe.get_doc("Agent Job Step", {"step_name": step, "agent_job": self.agent_job.name})
+        doc.duration = min(now() - start_time, MAX_DURATION)
+        if skipped:
+            doc.status = "Skipped"
+        else:
+            doc.output = output["message"]
+            doc.traceback = traceback
+            doc.status = "Success"
+            if output["exit_status"] != 0:
+                self.fail = True
+                doc.status = "Failure"
+        doc.save()
+        frappe.db.commit()
+
+    def setup_remote_connection(self):
+        try:
+            pkey = paramiko.RSAKey.from_private_key_file(get_ssh_key())
+            self.client = paramiko.SSHClient()
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.client.connect(self.server_ip, port=self.server_port, username=self.server_username, pkey=pkey)
+        except Exception as e:
+            self.fail = True
+            self.client = 0
+            log_error("Site Setup Error: Failed to connect to server", data=e)
+
+    def close_remote_connection(self):
+        if self.client:
+            self.client.close()
+
+    def execute_commands(self, commands):
+        output = {"message": "", "exit_status": 0}
+        traceback = ""
+
+        for command in commands:
+            _stdin, stdout, stderr = self.client.exec_command(command)
+            output["message"] += stdout.read().decode()
+            traceback += stderr.read().decode()
+            exit_status = stdout.channel.recv_exit_status()
+            if exit_status != 0:
+                output["exit_status"] = exit_status
+                break
+
+        return output, traceback
+
+    def set_bench_path(self):
+        self.frappe_bench_dir = "/home/ubuntu/frappe-bench"
+        self.bench_path = "/home/ubuntu/.local/bin/bench"
+
+    def enable_maintenance_mode(self):
+        start_time = now()
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} set-maintenance-mode on",
+            f"cd {self.frappe_bench_dir} && {self.bench_path} clear-cache"
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Enable Maintenance Mode", start_time, output, traceback)
+
+    def pull_changes(self):
+        start_time = now()
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} update --pull --no-backup",
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Pull Changes", start_time, output, traceback)
+
+    def bench_build(self):
+        start_time = now()
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} build",
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Bench Build", start_time, output, traceback)
+
+    def bench_migrate(self):
+        start_time = now()
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} migrate",
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Bench Migrate", start_time, output, traceback)
+
+    def bench_restart(self):
+        start_time = now()
+
+        if self.environment != "Production":
+            self.update_agent_job_step("Bench Restart", start_time, skipped=True)
+            return
+        
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} restart",
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Bench Restart", start_time, output, traceback)
+
+    def disable_maintenance_mode(self):
+        start_time = now()
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} set-maintenance-mode off",
+            f"cd {self.frappe_bench_dir} && {self.bench_path} clear-cache"
+        ]
+        output, traceback = self.execute_commands(commands)
+        self.update_agent_job_step("Disable Maintenance Mode", start_time, output, traceback)
+
+    def set_automatic_updates_in_site(self, update_enabled):
+        self.setup_remote_connection()
+        
+        if not self.client:
+            frappe.msgprint("Failed to connect to the server for setting automatic updates.", alert=True, indicator="red")
+            return
+        
+        commands = [
+            f"cd {self.frappe_bench_dir} && {self.bench_path} set-config auto_updates_enabled {update_enabled}",
+            f"cd {self.frappe_bench_dir} && {self.bench_path} clear-cache"
+        ]
+        output, traceback = self.execute_commands(commands)
+        
+        if output["exit_status"] != 0:
+            frappe.msgprint("Failed to set automatic updates in site.", alert=True, indicator="red")
+            return
+        
+        frappe.msgprint(
+            f"Automatic updates {'enabled' if update_enabled else 'disabled'} for site {self.site.name}.",
+            alert=True,
+            indicator="green" if update_enabled else "orange"
+        )
+
+
+def get_ssh_key():
+    ssh_key = frappe.db.get_single_value('Press Settings', 'default_ssh_key')
+    file_path = os.path.join(frappe.utils.get_site_path(), ssh_key.lstrip("/"))
+
+    return file_path

--- a/press/press/doctype/site/bizkit_site_update.py
+++ b/press/press/doctype/site/bizkit_site_update.py
@@ -61,7 +61,6 @@ class SiteUpdate:
             self.site.status = "Broken"
         else:
             self.site.status = "Active"
-            self.site.setup_wizard_complete = 1
         self.site.save()
         frappe.db.commit()
 

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -68,6 +68,7 @@
   "update_trigger_frequency",
   "update_trigger_time",
   "column_break_57",
+  "update_start_date",
   "update_on_weekday",
   "update_end_of_month",
   "update_on_day_of_month",
@@ -406,11 +407,11 @@
    "fieldname": "update_trigger_frequency",
    "fieldtype": "Select",
    "label": "Update Trigger Frequency",
-   "options": "Daily\nWeekly\nMonthly"
+   "options": "Daily\nWeekly\nEvery 2 Weeks\nMonthly"
   },
   {
    "default": "Sunday",
-   "depends_on": "eval:doc.update_trigger_frequency === 'Weekly'",
+   "depends_on": "eval:['Weekly', 'Every 2 Weeks'].includes(doc.update_trigger_frequency)",
    "fieldname": "update_on_weekday",
    "fieldtype": "Select",
    "label": "Update on Weekday",
@@ -640,6 +641,12 @@
    "label": "Restored From Backup",
    "options": "Site Backup",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.update_trigger_frequency === 'Every 2 Weeks'",
+   "fieldname": "update_start_date",
+   "fieldtype": "Date",
+   "label": "Update Start Date"
   }
  ],
  "links": [
@@ -714,7 +721,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2025-05-22 17:50:38.558835",
+ "modified": "2025-08-04 13:35:14.203653",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -184,7 +184,8 @@ class Site(Document, TagHelpers):
 		update_end_of_month: DF.Check
 		update_on_day_of_month: DF.Int
 		update_on_weekday: DF.Literal["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-		update_trigger_frequency: DF.Literal["Daily", "Weekly", "Monthly"]
+		update_start_date: DF.Date | None
+		update_trigger_frequency: DF.Literal["Daily", "Weekly", "Every 2 Weeks", "Monthly"]
 		update_trigger_time: DF.Time | None
 	# end: auto-generated types
 
@@ -210,6 +211,7 @@ class Site(Document, TagHelpers):
 		"skip_auto_updates",
 		"update_trigger_frequency",
 		"update_on_weekday",
+		"update_start_date",
 		"update_trigger_time",
 		"additional_system_user_created",
 		"domain",


### PR DESCRIPTION
This PR introduces automatic updates in Frappe Press to make multi-site deployments more efficient. This reduces the need to log into each site individually to check deployment status or trigger updates manually, streamlining the process and saving time.

<img width="926" height="407" alt="image" src="https://github.com/user-attachments/assets/94c44476-ba08-4e0d-88bf-28df4fb453e3" />
<img width="925" height="425" alt="image" src="https://github.com/user-attachments/assets/550bc1ab-6829-4ea0-a263-9bf67afea019" />

