### PR TITLE
feat: Production Server Lock

### DIFF
--- a/dashboard/src2/components/SiteActionCell.vue
+++ b/dashboard/src2/components/SiteActionCell.vue
@@ -83,7 +83,9 @@ function getSiteActionHandler(action) {
 		'Stop instance': onStopInstance,
 		'Reboot instance': onRebootInstance,
 		'Enable termination protection': onEnableTerminationProtection,
-		'Disable termination protection': onDisableTerminationProtection
+		'Disable termination protection': onDisableTerminationProtection,
+		'Unlock for termination': onUnlockForTermination,
+		'Lock for protection': onLockForProtection
 	};
 	if (actionHandlers[action]) {
 		actionHandlers[action].call(this);
@@ -166,6 +168,39 @@ function onDisableTerminationProtection() {
 			theme: 'red',
 			onClick({ hide }) {
 				return site.disableTerminationProtection.submit().then(hide);
+			}
+		}
+	});
+}
+
+function onUnlockForTermination() {
+	return confirmDialog({
+		title: 'Unlock for Termination',
+		message: `
+			Are you sure you want to unlock this site? This will allow the site to be deleted.
+		`,
+		primaryAction: {
+			label: 'Unlock',
+			variant: 'solid',
+			theme: 'red',
+			onClick({ hide }) {
+				return site.unlock.submit().then(hide);
+			}
+		}
+	});
+}
+
+function onLockForProtection() {
+	return confirmDialog({
+		title: 'Lock for Protection',
+		message: `
+			Are you sure you want to lock this site? This will prevent the site from being deleted.
+		`,
+		primaryAction: {
+			label: 'Lock',
+			variant: 'solid',
+			onClick({ hide }) {
+				return site.lock.submit().then(hide);
 			}
 		}
 	});

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -65,6 +65,8 @@ export default {
 		rebootInstance: 'reboot_instance',
 		enableTerminationProtection: 'enable_termination_protection',
 		disableTerminationProtection: 'disable_termination_protection',
+		unlock: 'unlock_for_termination',
+		lock: 'lock_for_protection',
 		dropSite: 'drop_site',
 		updateSite: 'update_site'
 	},

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -191,6 +191,8 @@
   "log_server",
   "telegram_alert_chat_id",
   "telegram_alerts_chat_group",
+  "maintenance_section",
+  "server_manager_role",
   "feature_flags_tab",
   "verify_cards_with_micro_charge",
   "enable_google_oauth",
@@ -1333,11 +1335,23 @@
    "fieldname": "default_ssh_key",
    "fieldtype": "Attach",
    "label": "Default SSH Key"
+  },
+  {
+   "fieldname": "maintenance_section",
+   "fieldtype": "Section Break",
+   "label": "Maintenance"
+  },
+  {
+   "description": "Role with permission to manage and shut down servers",
+   "fieldname": "server_manager_role",
+   "fieldtype": "Link",
+   "label": "Server Manager Role",
+   "options": "Role"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-02-04 19:30:46.938337",
+ "modified": "2026-04-07 19:02:13.302422",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -125,6 +125,7 @@ class PressSettings(Document):
 		remote_uploads_bucket: DF.Data | None
 		root_domain: DF.Data | None
 		rsa_key_size: DF.Literal["2048", "3072", "4096"]
+		server_manager_role: DF.Link | None
 		spaces_domain: DF.Link | None
 		ssh_certificate_authority: DF.Link | None
 		staging_expiry: DF.Int

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -79,13 +79,25 @@ frappe.ui.form.on('Server', {
 				__('Disable Termination Protection'),
 				'disable_termination_protection',
 				true,
-				frm.doc.termination_protection === 'Enabled' && frm.doc.environment !== 'Production',
+				frm.doc.termination_protection === 'Enabled' && !frm.doc.locked,
 			],
 			[
 				__('Terminate Instance'),
 				'terminate_instance',
 				true,
-				frm.doc.termination_protection === 'Disabled' && frm.doc.environment !== 'Production',
+				frm.doc.termination_protection === 'Disabled' && !frm.doc.locked,
+			],
+			[
+				__('Unlock for Termination'),
+				'unlock_for_termination',
+				true,
+				frm.doc.locked && frm.doc.environment === 'Production',
+			],
+			[
+				__('Lock to Protect from Termination'),
+				'lock_for_protection',
+				true,
+				!frm.doc.locked && frm.doc.environment === 'Production',
 			],
 			// [__('Update Agent'), 'update_agent', true, frm.doc.is_server_setup],
 			// [

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -24,6 +24,7 @@
   "is_self_hosted",
   "is_server_renamed",
   "public",
+  "locked",
   "billing_section",
   "team",
   "column_break_11",
@@ -643,10 +644,17 @@
    "fieldtype": "Data",
    "label": "Database Security Group",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "locked",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Locked"
   }
  ],
  "links": [],
- "modified": "2025-06-16 19:13:15.568230",
+ "modified": "2026-04-07 18:45:11.752693",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1328,6 +1328,7 @@ class Server(BaseServer):
 		is_standalone: DF.Check
 		is_standalone_setup: DF.Check
 		is_upstream_setup: DF.Check
+		locked: DF.Check
 		managed_database_service: DF.Link | None
 		mounts: DF.Table[ServerMount]
 		new_worker_allocation: DF.Check
@@ -2103,6 +2104,34 @@ class Server(BaseServer):
 	def disable_termination_protection(self):
 		termination_protection = "false"
 		self._change_termination_protection(termination_protection)
+
+	@frappe.whitelist()
+	def unlock_for_termination(self):
+		permitted_role = frappe.db.get_single_value("Press Settings", "server_manager_role")
+		if permitted_role not in frappe.get_roles(frappe.session.user):
+			frappe.throw(
+				_(
+					"You have no permission to perform this action. Please contact your Administrator.",
+				),
+				title=_("Not Allowed")
+			)
+
+		self.locked = 0
+		self.save()
+	
+	@frappe.whitelist()
+	def lock_for_protection(self):
+		permitted_role = frappe.db.get_single_value("Press Settings", "server_manager_role")
+		if permitted_role not in frappe.get_roles(frappe.session.user):
+			frappe.throw(
+				_(
+					"You have no permission to perform this action. Please contact your Administrator."
+				),
+				title=_("Not Allowed")
+			)
+
+		self.locked = 1
+		self.save()
 
 	@frappe.whitelist()
 	def terminate_instance(self):

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2638,6 +2638,16 @@ class Site(Document, TagHelpers):
 	def drop_site(self):
 		delete_site_and_related_docs(self)
 
+	@dashboard_whitelist()
+	def unlock_for_termination(self):
+		server = frappe.get_doc("Server", self.server)
+		server.unlock_for_termination()
+
+	@dashboard_whitelist()
+	def lock_for_protection(self):
+		server = frappe.get_doc("Server", self.server)
+		server.lock_for_protection()
+
 	@frappe.whitelist()
 	def get_actions(self):
 		is_group_public = frappe.get_cached_value("Release Group", self.group, "public")
@@ -2645,6 +2655,12 @@ class Site(Document, TagHelpers):
 		server_state = server.instance_state
 		termination_protection = server.termination_protection
 		environment = server.environment
+		locked = cint(server.locked)
+		permitted = False
+
+		permitted_role = frappe.db.get_single_value("Press Settings", "server_manager_role")
+		if permitted_role in frappe.get_roles(frappe.session.user):
+			permitted = True
 
 		actions = [
 			{
@@ -2669,12 +2685,27 @@ class Site(Document, TagHelpers):
 				"doc_method": "reboot_instance",
 			},
 			{
+				"action": "Lock for protection",
+				"description": "Lock this site to disable deletion and protect the production server",
+				"button_label": "Lock",
+				"doc_method": "lock_for_protection",
+				"condition": environment == "Production" and permitted and not locked,
+			},
+			{
+				"group": "Dangerous Actions",
+				"action": "Unlock for termination",
+				"description": "This site is locked to prevent accidental deletion of a production server. Unlock to proceed with deletion",
+				"button_label": "Unlock",
+				"doc_method": "unlock_for_termination",
+				"condition": environment == "Production" and permitted and locked,
+			},
+			{
 				"group": "Dangerous Actions",
 				"action": "Disable termination protection",
 				"description": "Termination protection prevents accidental deletion of your site. To delete your site, you must disable termination protection first",
 				"button_label": "Disable",
 				"doc_method": "disable_termination_protection",
-				"condition": termination_protection == "Enabled" and environment != "Production",
+				"condition": termination_protection == "Enabled" and permitted and not locked,
 			},
 			{
 				"group": "Dangerous Actions",
@@ -2682,7 +2713,7 @@ class Site(Document, TagHelpers):
 				"description": "Termination protection prevents accidental deletion of your site",
 				"button_label": "Enable",
 				"doc_method": "enable_termination_protection",
-				"condition": termination_protection == "Disabled",
+				"condition": termination_protection == "Disabled" and permitted and not locked,
 			},
 			{
 				"group": "Dangerous Actions",
@@ -2690,7 +2721,7 @@ class Site(Document, TagHelpers):
 				"description": "When you drop your site, all site data is deleted forever",
 				"button_label": "Drop",
 				"doc_method": "drop_site",
-				"condition": termination_protection == "Disabled" and environment != "Production",
+				"condition": termination_protection == "Disabled" and permitted and not locked,
 			},
 		]
 


### PR DESCRIPTION
This PR introduces lock/unlock controls for production sites, adding an extra layer of protection for deletions in Frappe Press. Deletion permissions are restricted to the Server Manager role defined in Press Settings.

<img width="1511" height="737" alt="image" src="https://github.com/user-attachments/assets/bdb15c88-f7d2-48ed-930f-f75d5533d769" />
<img width="1182" height="706" alt="image" src="https://github.com/user-attachments/assets/1a3a544d-2002-42ca-9dc4-035134d37c80" />
