### PR TITLE
feat: Rollback process for server setup

### DIFF
--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -116,9 +116,11 @@ def force_delete(doctype, name):
         link_dt, link_field, issingle = lf["parent"], lf["fieldname"], lf["issingle"]
         if issingle:
             continue
-        for row in frappe.db.get_values(link_dt, {link_field: name}, ["name", "parent", "parenttype"], as_dict=True):
-            target_dt = row.parenttype if row.parent else link_dt
-            target_name = row.parent or row.name
+        is_child = frappe.get_meta(link_dt).istable
+        fields = ["name", "parent", "parenttype"] if is_child else ["name"]
+        for row in frappe.db.get_values(link_dt, {link_field: name}, fields, as_dict=True):
+            target_dt = row.parenttype if is_child and row.parent else link_dt
+            target_name = row.parent if is_child and row.parent else row.name
             try:
                 frappe.delete_doc(target_dt, target_name, force=True, ignore_permissions=True)
             except Exception:
@@ -126,15 +128,18 @@ def force_delete(doctype, name):
 
     # Delete all Dynamic Link references (e.g. Press Notification via document_type/document_name)
     for df in get_dynamic_link_map().get(doctype, []):
-        if frappe.get_meta(df.parent).issingle:
+        meta = frappe.get_meta(df.parent)
+        if meta.issingle:
             continue
+        is_child = meta.istable
+        extra = ", `parent`, `parenttype`" if is_child else ""
         for row in frappe.db.sql(
-            f"SELECT `name`, `parent`, `parenttype` FROM `tab{df.parent}` WHERE `{df.options}`=%s AND `{df.fieldname}`=%s",
+            f"SELECT `name`{extra} FROM `tab{df.parent}` WHERE `{df.options}`=%s AND `{df.fieldname}`=%s",
             (doctype, name),
             as_dict=True,
         ):
-            target_dt = row.parenttype if row.parent else df.parent
-            target_name = row.parent or row.name
+            target_dt = row.parenttype if is_child and row.parent else df.parent
+            target_name = row.parent if is_child and row.parent else row.name
             try:
                 frappe.delete_doc(target_dt, target_name, force=True, ignore_permissions=True)
             except Exception:
@@ -168,24 +173,24 @@ def rollback(created, is_new):
     if app_server := created.get("app_server"):
         try:
             frappe.get_doc("Server", app_server).terminate_instance()
-            force_delete("Server", app_server)
         except Exception:
             frappe.log_error("Rollback: failed to terminate App Server", app_server)
+        force_delete("Server", app_server)
 
     if is_new:
         if db_server := created.get("db_server"):
             try:
                 frappe.get_doc("Database Server", db_server).terminate_instance()
-                force_delete("Database Server", db_server)
             except Exception:
                 frappe.log_error("Rollback: failed to terminate Database Server", db_server)
+            force_delete("Database Server", db_server)
 
         if cluster := created.get("cluster"):
             try:
                 frappe.get_doc("Cluster", cluster).delete_vpc()
-                force_delete("Cluster", cluster)
             except Exception:
                 frappe.log_error("Rollback: failed to delete Cluster VPC", cluster)
+            force_delete("Cluster", cluster)
 
 
 def get_site_plan_details(site_plan):

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -44,34 +44,41 @@ def _new(args):
     site_plan_details = get_site_plan_details(site_plan)
     domain = frappe.db.get_value("Root Domain", {"environment": environment}, "name")
     is_new = cluster == "New Client"
+    created = {}
 
     try:
         if is_new:
             print("Creating new client")
             print("Creating cluster")
             cluster = create_cluster(project_name)
+            created["cluster"] = cluster
             print("Creating database server")
             db_server = create_database_server(project_name, cluster, site_plan_details)
+            created["db_server"] = db_server
         else:
             cluster = project_name
             db_server = frappe.db.get_value("Database Server", {"cluster": cluster, "is_server_setup": 1}, "name")
 
         print("Creating app server")
         app_server = create_app_server(project_name, cluster, environment, site_plan_details, db_server, domain)
+        created["app_server"] = app_server
 
         if release_group := get_existing_release_group(apps):
             print("Adding server to existing release group")
         else:
             print("Creating new release group")
             release_group = create_release_group(project_name, apps, team)
+            created["release_group"] = release_group
             print("Creating deploy candidate")
             create_deploy_candidate(release_group)
 
         print("Adding server to release group and creating bench")
         bench = add_server_to_release_group(release_group, app_server)
+        created["bench"] = bench
 
         print("Creating site")
         site = create_site(company_name, company_name_abbr, bench, product, tenancy, release_group, cluster, app_server, project_name, team, domain, site_plan, backup)
+        created["site"] = site.name
 
         create_notification({
             "team": team,
@@ -86,15 +93,61 @@ def _new(args):
         if is_new:
             cluster = project_name
 
+        rollback(created, is_new)
+
         create_notification({
             "team": team,
             "doctype": "Cluster",
             "docname": cluster,
             "title": "Site Creation Failed",
-            "message": "An error occurred while creating the site. Please see the traceback for more details.",
+            "message": "An error occurred while creating the site. Automated rollback has been initiated. Please see the traceback for more details.",
             "traceback": str(e),
         })
         raise e
+
+
+def rollback(created, is_new):
+    # Tear down in reverse creation order; swallow each error so one failure
+    # doesn't block the remaining cleanup steps.
+    if site := created.get("site"):
+        try:
+            frappe.delete_doc("Site", site)
+            frappe.db.commit()
+        except Exception:
+            frappe.log_error("Rollback: failed to delete Site", site)
+
+    if bench := created.get("bench"):
+        try:
+            frappe.delete_doc("Bench", bench)
+            frappe.db.commit()
+        except Exception:
+            frappe.log_error("Rollback: failed to delete Bench", bench)
+
+    if release_group := created.get("release_group"):
+        try:
+            frappe.delete_doc("Release Group", release_group)
+            frappe.db.commit()
+        except Exception:
+            frappe.log_error("Rollback: failed to delete Release Group", release_group)
+
+    if app_server := created.get("app_server"):
+        try:
+            frappe.get_doc("Server", app_server).terminate_instance()
+        except Exception:
+            frappe.log_error("Rollback: failed to terminate App Server", app_server)
+
+    if is_new:
+        if db_server := created.get("db_server"):
+            try:
+                frappe.get_doc("Database Server", db_server).terminate_instance()
+            except Exception:
+                frappe.log_error("Rollback: failed to terminate Database Server", db_server)
+
+        if cluster := created.get("cluster"):
+            try:
+                frappe.get_doc("Cluster", cluster).delete_vpc()
+            except Exception:
+                frappe.log_error("Rollback: failed to delete Cluster VPC", cluster)
 
 
 def get_site_plan_details(site_plan):

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -1,5 +1,7 @@
 import frappe
 import re
+from frappe.model.dynamic_links import get_dynamic_link_map
+from frappe.model.rename_doc import get_link_fields
 
 
 def slugify(s):
@@ -106,33 +108,65 @@ def _new(args):
         raise e
 
 
+def force_delete(doctype, name):
+    # Delete all standard Link references
+    for lf in get_link_fields(doctype):
+        link_dt, link_field, issingle = lf["parent"], lf["fieldname"], lf["issingle"]
+        if issingle:
+            continue
+        for row in frappe.db.get_values(link_dt, {link_field: name}, ["name", "parent", "parenttype"], as_dict=True):
+            target_dt = row.parenttype if row.parent else link_dt
+            target_name = row.parent or row.name
+            try:
+                frappe.delete_doc(target_dt, target_name, force=True, ignore_permissions=True)
+            except Exception:
+                frappe.log_error(f"force_delete: failed to delete linked {target_dt}", target_name)
+
+    # Delete all Dynamic Link references (e.g. Press Notification via document_type/document_name)
+    for df in get_dynamic_link_map().get(doctype, []):
+        if frappe.get_meta(df.parent).issingle:
+            continue
+        for row in frappe.db.sql(
+            f"SELECT `name`, `parent`, `parenttype` FROM `tab{df.parent}` WHERE `{df.options}`=%s AND `{df.fieldname}`=%s",
+            (doctype, name),
+            as_dict=True,
+        ):
+            target_dt = row.parenttype if row.parent else df.parent
+            target_name = row.parent or row.name
+            try:
+                frappe.delete_doc(target_dt, target_name, force=True, ignore_permissions=True)
+            except Exception:
+                frappe.log_error(f"force_delete: failed to delete dynamic-linked {target_dt}", target_name)
+
+    frappe.delete_doc(doctype, name, ignore_permissions=True)
+    frappe.db.commit()
+
+
 def rollback(created, is_new):
     # Tear down in reverse creation order; swallow each error so one failure
     # doesn't block the remaining cleanup steps.
     if site := created.get("site"):
         try:
-            frappe.delete_doc("Site", site)
-            frappe.db.commit()
+            force_delete("Site", site)
         except Exception:
             frappe.log_error("Rollback: failed to delete Site", site)
 
     if bench := created.get("bench"):
         try:
-            frappe.delete_doc("Bench", bench)
-            frappe.db.commit()
+            force_delete("Bench", bench)
         except Exception:
             frappe.log_error("Rollback: failed to delete Bench", bench)
 
     if release_group := created.get("release_group"):
         try:
-            frappe.delete_doc("Release Group", release_group)
-            frappe.db.commit()
+            force_delete("Release Group", release_group)
         except Exception:
             frappe.log_error("Rollback: failed to delete Release Group", release_group)
 
     if app_server := created.get("app_server"):
         try:
             frappe.get_doc("Server", app_server).terminate_instance()
+            force_delete("Server", app_server)
         except Exception:
             frappe.log_error("Rollback: failed to terminate App Server", app_server)
 
@@ -140,12 +174,14 @@ def rollback(created, is_new):
         if db_server := created.get("db_server"):
             try:
                 frappe.get_doc("Database Server", db_server).terminate_instance()
+                force_delete("Database Server", db_server)
             except Exception:
                 frappe.log_error("Rollback: failed to terminate Database Server", db_server)
 
         if cluster := created.get("cluster"):
             try:
                 frappe.get_doc("Cluster", cluster).delete_vpc()
+                force_delete("Cluster", cluster)
             except Exception:
                 frappe.log_error("Rollback: failed to delete Cluster VPC", cluster)
 

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -9,9 +9,24 @@ def slugify(s):
     s = re.sub(r'^-+|-+$', '', s)
     return s
 
+
+def unique_name(doctype, filters, base_name):
+    if frappe.db.exists(doctype, filters):
+        count = frappe.db.count(doctype, filters) + 1
+        return base_name + str(count)
+    return base_name
+
+
+def assert_server_active(doc, label):
+    doc.reload()
+    if doc.status == "Broken":
+        frappe.throw(f"{label} setup failed")
+
+
 @frappe.whitelist()
 def new(args):
     frappe.enqueue(_new, args=args, queue="long", timeout=3600)
+
 
 def _new(args):
     cluster = args.get("cluster")
@@ -24,44 +39,40 @@ def _new(args):
     tenancy = args.get("tenancy")
     site_plan = args.get("site_plan")
     backup = args.get("backup")
-    team = frappe.db.get_value("Team", {"team_title": "DevOps"}, "name")
-    
-    site_plan_details = get_site_plan_details(site_plan)
-    db_instance_type = site_plan_details["db_instance_type"]
-    db_storage_size = site_plan_details["db_storage_size"]
-    app_instance_type = site_plan_details["app_instance_type"]
-    app_volume_size = site_plan_details["app_volume_size"]
 
+    team = frappe.db.get_value("Team", {"team_title": "DevOps"}, "name")
+    site_plan_details = get_site_plan_details(site_plan)
     domain = frappe.db.get_value("Root Domain", {"environment": environment}, "name")
+    is_new = cluster == "New Client"
 
     try:
-        if is_new_client(cluster):
+        if is_new:
             print("Creating new client")
             print("Creating cluster")
             cluster = create_cluster(project_name)
             print("Creating database server")
-            db_server = create_database_server(project_name, cluster, db_instance_type, db_storage_size)
+            db_server = create_database_server(project_name, cluster, site_plan_details)
         else:
             cluster = project_name
             db_server = frappe.db.get_value("Database Server", {"cluster": cluster, "is_server_setup": 1}, "name")
 
         print("Creating app server")
-        app_server = create_app_server(project_name, cluster, environment, app_instance_type, app_volume_size, db_server, domain)
+        app_server = create_app_server(project_name, cluster, environment, site_plan_details, db_server, domain)
 
         if release_group := get_existing_release_group(apps):
             print("Adding server to existing release group")
-            bench = add_server_to_release_group(release_group, app_server)
         else:
             print("Creating new release group")
             release_group = create_release_group(project_name, apps, team)
             print("Creating deploy candidate")
-            deploy_candidate = create_deploy_candidate(release_group)
-            print("Adding server to release group and creating bench")
-            bench = add_server_to_release_group(release_group, app_server)
-        
+            create_deploy_candidate(release_group)
+
+        print("Adding server to release group and creating bench")
+        bench = add_server_to_release_group(release_group, app_server)
+
         print("Creating site")
         site = create_site(company_name, company_name_abbr, bench, product, tenancy, release_group, cluster, app_server, project_name, team, domain, site_plan, backup)
-        
+
         create_notification({
             "team": team,
             "doctype": "Site",
@@ -72,7 +83,7 @@ def _new(args):
         })
 
     except Exception as e:
-        if is_new_client(cluster):
+        if is_new:
             cluster = project_name
 
         create_notification({
@@ -85,14 +96,16 @@ def _new(args):
         })
         raise e
 
+
 def get_site_plan_details(site_plan):
-    site_plan_doc = frappe.get_doc("Site Plan", site_plan)
+    doc = frappe.get_doc("Site Plan", site_plan)
     return {
-        "db_instance_type": site_plan_doc.db_instance_type,
-        "db_storage_size": site_plan_doc.max_database_usage / 1024,
-        "app_instance_type": site_plan_doc.instance_type,
-        "app_volume_size": site_plan_doc.max_storage_usage / 1024,
+        "db_instance_type": doc.db_instance_type,
+        "db_storage_size": doc.max_database_usage / 1024,
+        "app_instance_type": doc.instance_type,
+        "app_volume_size": doc.max_storage_usage / 1024,
     }
+
 
 def create_cluster(project_name):
     cluster_doc = frappe.get_doc({
@@ -110,7 +123,8 @@ def create_cluster(project_name):
     cluster_doc.prepare_vpc()
     return cluster_doc.name
 
-def create_database_server(project_name, cluster_name, db_instance_type, db_storage_size):
+
+def create_database_server(project_name, cluster_name, plan):
     domain = frappe.db.get_value("Root Domain", {"environment": "Database"}, "name")
 
     database_doc = frappe.get_doc({
@@ -121,8 +135,8 @@ def create_database_server(project_name, cluster_name, db_instance_type, db_stor
         "title": project_name,
         "provider": "AWS RDS",
         "cluster": cluster_name,
-        "instance_type": db_instance_type,
-        "storage_size": db_storage_size,
+        "instance_type": plan["db_instance_type"],
+        "storage_size": plan["db_storage_size"],
         "is_primary": 1,
         "ssh_user": "ubuntu",
         "ssh_port": 22,
@@ -135,21 +149,13 @@ def create_database_server(project_name, cluster_name, db_instance_type, db_stor
     })
     database_doc.insert()
     frappe.db.commit()
-    database_doc.reload()
     database_doc._setup_server()
-
-    database_doc.reload()
-    if database_doc.status == "Broken":
-        frappe.throw("Database Server setup failed")
-
+    assert_server_active(database_doc, "Database Server")
     return database_doc.name
 
-def create_app_server(project_name, cluster_name, environment, app_instance_type, app_volume_size, database_server_name, domain):
-    hostname = slugify(project_name)
 
-    if frappe.db.exists("Server", {"hostname": hostname, "domain": domain}):
-        count = frappe.db.count("Server", {"hostname": hostname, "domain": domain}) + 1
-        hostname += str(count)
+def create_app_server(project_name, cluster_name, environment, plan, database_server_name, domain):
+    hostname = unique_name("Server", {"hostname": slugify(project_name), "domain": domain}, slugify(project_name))
 
     app_server_doc = frappe.get_doc({
         "doctype": "Server",
@@ -160,29 +166,26 @@ def create_app_server(project_name, cluster_name, environment, app_instance_type
         "provider": "AWS EC2",
         "cluster": cluster_name,
         "environment": environment,
-        "instance_type": app_instance_type,
-        "volume_size": app_volume_size,
+        "instance_type": plan["app_instance_type"],
+        "volume_size": plan["app_volume_size"],
         "ssh_user": "ubuntu",
         "ssh_port": 22,
         "database_server": database_server_name,
     })
     app_server_doc.insert()
     frappe.db.commit()
-    app_server_doc.reload()
     app_server_doc._setup_server()
     app_server_doc.connect_to_rds()
-
-    app_server_doc.reload()
-    if app_server_doc.status == "Broken":
-        frappe.throw("App Server setup failed")
-
+    assert_server_active(app_server_doc, "App Server")
     return app_server_doc.name
+
 
 def create_release_group(project_name, apps, team):
     release_group_apps = []
     for app in apps:
         app_source = frappe.db.get_value("App Source", {"app": app, "enabled": 1}, "name")
         release_group_apps.append({"app": app, "source": app_source})
+
     release_group_doc = frappe.get_doc({
         "doctype": "Release Group",
         "title": project_name,
@@ -197,13 +200,15 @@ def create_release_group(project_name, apps, team):
     release_group_doc.reload()
     return release_group_doc.name
 
+
 def add_server_to_release_group(release_group, app_server_name):
     release_group_doc = frappe.get_doc("Release Group", release_group)
-    deploy = release_group_doc.add_server(app_server_name, True) # includes creation of Deploy and Bench
+    deploy = release_group_doc.add_server(app_server_name, True)
     bench = frappe.db.get_value("Deploy Bench", filters={"parent": deploy.name}, fieldname=["bench"])
     frappe.db.set_value("Bench", bench, "status", "Active")
     frappe.db.commit()
     return bench
+
 
 def create_deploy_candidate(release_group):
     release_group_doc = frappe.get_doc("Release Group", release_group)
@@ -212,31 +217,19 @@ def create_deploy_candidate(release_group):
     frappe.db.commit()
     return deploy_candidate.name
 
-def create_bench(deploy_candidate):
-    deploy_candidate_doc = frappe.get_doc("Deploy Candidate", deploy_candidate)
-    deploy = deploy_candidate_doc.deploy() # creates Deploy and Bench
-    bench = frappe.db.get_value("Deploy Bench", filters={"parent": deploy}, fieldname=["bench"])
-    frappe.db.set_value("Bench", bench, "status", "Active")
-    frappe.db.commit()
-    return bench
 
 def create_site(company_name, company_name_abbr, bench_name, product, tenancy, release_group, cluster_name, app_server_name, project_name, team, domain, site_plan, backup):
     bench_doc = frappe.get_doc("Bench", bench_name)
     bench_apps = [{"app": app.app} for app in bench_doc.apps]
 
     server_doc = frappe.get_doc("Server", app_server_name)
-    server_ip = server_doc.ip
+    subdomain = unique_name("Site", {"subdomain": slugify(project_name), "domain": domain}, slugify(project_name))
 
-    subdomain = slugify(project_name)
-    if frappe.db.exists("Site", {"subdomain": subdomain, "domain": domain}):
-        count = frappe.db.count("Site", {"subdomain": subdomain, "domain": domain}) + 1
-        subdomain += str(count)
-    
     site_doc = frappe.get_doc({
         "doctype": "Site",
         "company_name": company_name,
         "company_name_abbreviation": company_name_abbr,
-        "site_url": f"http://{server_ip}",
+        "site_url": f"http://{server_doc.ip}",
         "bench": bench_name,
         "product": product,
         "tenancy": tenancy,
@@ -248,19 +241,14 @@ def create_site(company_name, company_name_abbr, bench_name, product, tenancy, r
         "team": team,
         "apps": bench_apps,
         "plan": site_plan,
-        "restored_from_backup": backup
+        "restored_from_backup": backup,
     })
     site_doc.insert()
     frappe.db.commit()
     site_doc.reload()
     site_doc.install_site()
-
     return site_doc
 
-def is_new_client(cluster):
-    if cluster == "New Client":
-        return True
-    return False
 
 def get_existing_release_group(apps):
     release_groups = frappe.get_all("Release Group", filters={"version": "Version 13", "public": 1, "enabled": 1})
@@ -269,27 +257,21 @@ def get_existing_release_group(apps):
         release_group_apps = [app.app for app in release_group_apps]
         if not list(set(apps) - set(release_group_apps)):
             return release_group.name
-        
+
+
 def create_notification(details):
     team = details.get("team")
-    doctype = details.get("doctype")
-    docname = details.get("docname")
-    title = details.get("title")
-    message = details.get("message")
     traceback = details.get("traceback")
-    notif_class = "Success"
-    if traceback:
-        notif_class = "Error"
 
     notification_doc = frappe.get_doc({
         "doctype": "Press Notification",
         "team": team,
         "type": "Site Update",
-        "document_type": doctype,
-        "document_name": docname,
-        "class": notif_class,
-        "title": title,
-        "message": message,
+        "document_type": details.get("doctype"),
+        "document_name": details.get("docname"),
+        "class": "Error" if traceback else "Success",
+        "title": details.get("title"),
+        "message": details.get("message"),
         "traceback": traceback,
     })
     notification_doc.insert()

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -57,6 +57,7 @@ def _new(args):
             print("Creating database server")
             db_server = create_database_server(project_name, cluster, site_plan_details)
             created["db_server"] = db_server
+            setup_database_server(db_server)
         else:
             cluster = project_name
             db_server = frappe.db.get_value("Database Server", {"cluster": cluster, "is_server_setup": 1}, "name")
@@ -64,6 +65,7 @@ def _new(args):
         print("Creating app server")
         app_server = create_app_server(project_name, cluster, environment, site_plan_details, db_server, domain)
         created["app_server"] = app_server
+        setup_app_server(app_server)
 
         if release_group := get_existing_release_group(apps):
             print("Adding server to existing release group")
@@ -238,9 +240,13 @@ def create_database_server(project_name, cluster_name, plan):
     })
     database_doc.insert()
     frappe.db.commit()
+    return database_doc.name
+
+
+def setup_database_server(db_server_name):
+    database_doc = frappe.get_doc("Database Server", db_server_name)
     database_doc._setup_server()
     assert_server_active(database_doc, "Database Server")
-    return database_doc.name
 
 
 def create_app_server(project_name, cluster_name, environment, plan, database_server_name, domain):
@@ -263,10 +269,14 @@ def create_app_server(project_name, cluster_name, environment, plan, database_se
     })
     app_server_doc.insert()
     frappe.db.commit()
+    return app_server_doc.name
+
+
+def setup_app_server(app_server_name):
+    app_server_doc = frappe.get_doc("Server", app_server_name)
     app_server_doc._setup_server()
     app_server_doc.connect_to_rds()
     assert_server_active(app_server_doc, "App Server")
-    return app_server_doc.name
 
 
 def create_release_group(project_name, apps, team):

--- a/press/playbooks/delete_vpc.yml
+++ b/press/playbooks/delete_vpc.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    vpc_id: '{{ vpc_id }}'
+    route_table_id: '{{ route_table_id }}'
+    subnet_cidr: '{{ subnet_cidr }}'
+    subnet_2_cidr: '{{ subnet_2_cidr }}'
+  roles:
+    - role: delete_vpc

--- a/press/playbooks/roles/delete_vpc/tasks/main.yml
+++ b/press/playbooks/roles/delete_vpc/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Delete route table
+  amazon.aws.ec2_vpc_route_table:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    route_table_id: '{{ route_table_id }}'
+    vpc_id: '{{ vpc_id }}'
+    state: absent
+    region: ap-southeast-1
+  when: route_table_id | length > 0
+  ignore_errors: true
+
+- name: Detach and delete internet gateway
+  amazon.aws.ec2_vpc_igw:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    vpc_id: '{{ vpc_id }}'
+    state: absent
+    region: ap-southeast-1
+  ignore_errors: true
+
+- name: Delete subnet 1
+  amazon.aws.ec2_vpc_subnet:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    vpc_id: '{{ vpc_id }}'
+    cidr: '{{ subnet_cidr }}'
+    state: absent
+    region: ap-southeast-1
+  when: subnet_cidr | length > 0
+  ignore_errors: true
+
+- name: Delete subnet 2
+  amazon.aws.ec2_vpc_subnet:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    vpc_id: '{{ vpc_id }}'
+    cidr: '{{ subnet_2_cidr }}'
+    state: absent
+    region: ap-southeast-1
+  when: subnet_2_cidr | length > 0
+  ignore_errors: true
+
+- name: Delete VPC
+  amazon.aws.ec2_vpc_net:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    vpc_id: '{{ vpc_id }}'
+    state: absent
+    region: ap-southeast-1
+  ignore_errors: true

--- a/press/playbooks/roles/terminate_rds/tasks/main.yml
+++ b/press/playbooks/roles/terminate_rds/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Delete RDS instance
+  amazon.aws.rds_instance:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    db_instance_identifier: '{{ instance_abbr }}-db'
+    state: absent
+    skip_final_snapshot: true
+    region: ap-southeast-1
+  ignore_errors: true
+
+- name: Delete RDS subnet group
+  amazon.aws.rds_subnet_group:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    name: '{{ instance_abbr }}-db'
+    state: absent
+    region: ap-southeast-1
+  ignore_errors: true
+
+- name: Delete RDS security group
+  amazon.aws.ec2_security_group:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    group_id: '{{ security_group_id }}'
+    state: absent
+    region: ap-southeast-1
+  when: security_group_id | length > 0
+  ignore_errors: true

--- a/press/playbooks/terminate_rds.yml
+++ b/press/playbooks/terminate_rds.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    instance_abbr: '{{ instance_abbr }}'
+    security_group_id: '{{ security_group_id }}'
+  roles:
+    - role: terminate_rds

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -889,5 +889,34 @@ class Cluster(Document):
 		except Exception:
 			self.status = "Pending"
 			log_error("VPC Setup Exception", server=self.as_dict())
-		
+
 		self.save()
+
+	def delete_vpc(self):
+		settings = frappe.get_single("Press Settings")
+		aws_access_key_id = settings.aws_access_key_id
+		aws_secret_access_key = settings.get_password("aws_secret_access_key")
+
+		try:
+			ansible = Ansible(
+				playbook="delete_vpc.yml",
+				server=frappe._dict({"doctype": self.doctype, "name": self.name, "ip": self.name.lower().replace(" ", "_")}),
+				user="ubuntu",
+				port=22,
+				variables={
+					"vpc_id": self.vpc_id or "",
+					"route_table_id": self.route_table_id or "",
+					"subnet_cidr": self.subnet_cidr_block or "",
+					"subnet_2_cidr": self.subnet_2_cidr_block or "",
+					"ec2_access_key": aws_access_key_id,
+					"ec2_secret_key": aws_secret_access_key,
+				},
+			)
+			play = ansible.run()
+			if play.status == "Success":
+				frappe.delete_doc("Cluster", self.name)
+				frappe.db.commit()
+			else:
+				log_error("VPC Deletion Failed", server=self.as_dict())
+		except Exception:
+			log_error("VPC Deletion Exception", server=self.as_dict())

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -913,10 +913,7 @@ class Cluster(Document):
 				},
 			)
 			play = ansible.run()
-			if play.status == "Success":
-				frappe.delete_doc("Cluster", self.name)
-				frappe.db.commit()
-			else:
+			if play.status != "Success":
 				log_error("VPC Deletion Failed", server=self.as_dict())
 		except Exception:
 			log_error("VPC Deletion Exception", server=self.as_dict())

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -408,6 +408,35 @@ class DatabaseServer(BaseServer):
 			log_error("Database Server Setup Exception", server=self.as_dict())
 		self.save()
 
+	def terminate_instance(self):
+		settings = frappe.get_single("Press Settings")
+		aws_access_key_id = settings.aws_access_key_id
+		aws_secret_access_key = settings.get_password("aws_secret_access_key")
+
+		try:
+			ansible = Ansible(
+				playbook="terminate_rds.yml",
+				server=self,
+				user=self._ssh_user(),
+				port=self._ssh_port(),
+				variables={
+					"instance_abbr": self.hostname_abbreviation,
+					"security_group_id": self.security_group or "",
+					"ec2_access_key": aws_access_key_id,
+					"ec2_secret_key": aws_secret_access_key,
+				},
+			)
+			play = ansible.run()
+			self.reload()
+			if play.status == "Success":
+				self.status = "Archived"
+				self.is_server_setup = False
+			else:
+				log_error("RDS Termination Failed", server=self.as_dict())
+		except Exception:
+			log_error("RDS Termination Exception", server=self.as_dict())
+		self.save()
+
 	def format_backup_window(self):
 		# hh24:mi-hh24:mi
 

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -474,7 +474,8 @@ class DatabaseServer(BaseServer):
 		reference_date = datetime(2023, 1, 1)  # A known Sunday, for reference
 		start_day_index = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].index(day)
 
-		start_dt = reference_date + timedelta(days=start_day_index) + self.maintenance_window_start_time
+		start_time = datetime.strptime(f"{self.maintenance_window_start_time}", "%H:%M:%S")
+		start_dt = reference_date + timedelta(days=start_day_index, hours=start_time.hour, minutes=start_time.minute)
 		start_dt = start_dt.replace(second=0, microsecond=0)
 		start_dt = start_dt.replace(tzinfo=timezone.utc) - utc8_offset
 


### PR DESCRIPTION
This PR adds automatic cleanup when site creation fails at any step. A created dict tracks each provisioned resource as it's created, and rollback() tears them down in reverse order (site → bench → release group → app server → db server → cluster), swallowing individual errors so one cleanup failure doesn't block the rest.