### PR TITLE
feat: Temporary site takedown system

### DIFF
--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -391,16 +391,16 @@ export default {
 				},
 				{
 					label: 'Takedown Date',
-					value: this.$site.doc?.takedown_date || (this.$team?.doc?.is_desk_user ? '' : 'Not set'),
+					value: this.$site.doc?.takedown_date || 'Not set',
 					suffix: !this.$site.doc?.takedown_date && this.$team?.doc?.is_desk_user
 						? h(Button, {
-								variant: 'outline',
+								variant: 'subtle',
 								size: 'sm',
 								onClick: this.showSetTakedownDateDialog
 							}, () => 'Set')
 						: this.$site.doc?.takedown_date && this.$team?.doc?.is_desk_user
 						? h(Button, {
-								variant: 'ghost',
+								variant: 'subtle',
 								size: 'sm',
 								onClick: this.showSetTakedownDateDialog
 							}, () => 'Change')

--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -47,6 +47,12 @@
 				Upgrade Plan
 			</Button>
 		</DismissableBanner>
+		<AlertBanner
+			v-if="$site.doc.takedown_date"
+			class="col-span-1 lg:col-span-2"
+			type="warning"
+			:title="`This site is scheduled to be suspended on ${$site.doc.takedown_date}.`"
+		/>
 		<div class="rounded-md border">
 			<div class="h-12 border-b px-5 py-4">
 				<h2 class="text-lg font-medium text-gray-900">Site Information</h2>

--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -260,7 +260,7 @@ import { toast } from 'vue-sonner';
 import InfoIcon from '~icons/lucide/info';
 import DismissableBanner from './DismissableBanner.vue';
 import { getToastErrorMessage } from '../utils/toast';
-import { renderDialog } from '../utils/components';
+import { confirmDialog, renderDialog } from '../utils/components';
 import SiteDailyUsage from './SiteDailyUsage.vue';
 import AlertBanner from './AlertBanner.vue';
 import { trialDays } from '../utils/site';
@@ -323,6 +323,28 @@ export default {
 			);
 			renderDialog(h(TagsDialog, { doctype: 'Site', docname: this.site }));
 		},
+		showSetTakedownDateDialog() {
+			confirmDialog({
+				title: 'Set Takedown Date',
+				fields: [
+					{
+						label: 'Takedown Date',
+						fieldname: 'takedown_date',
+						fieldtype: 'Date',
+						description:
+							'The site will be suspended on this date. Leave empty to remove the scheduled takedown.'
+					}
+				],
+				initialValues: {
+					takedown_date: this.$site.doc.takedown_date || ''
+				},
+				onSuccess: ({ data: values }) => {
+					this.$site.setTakedownDate.submit({
+						date: values.takedown_date || null
+					});
+				}
+			});
+		},
 		trialDays
 	},
 	computed: {
@@ -368,6 +390,23 @@ export default {
 							target: '_blank'
 						}
 					)
+				},
+				{
+					label: 'Takedown Date',
+					value: this.$site.doc?.takedown_date || (this.$team?.doc?.is_desk_user ? '' : 'Not set'),
+					suffix: !this.$site.doc?.takedown_date && this.$team?.doc?.is_desk_user
+						? h(Button, {
+								variant: 'outline',
+								size: 'sm',
+								onClick: this.showSetTakedownDateDialog
+							}, () => 'Set')
+						: this.$site.doc?.takedown_date && this.$team?.doc?.is_desk_user
+						? h(Button, {
+								variant: 'ghost',
+								size: 'sm',
+								onClick: this.showSetTakedownDateDialog
+							}, () => 'Change')
+						: null
 				}
 			];
 		},

--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -330,15 +330,13 @@ export default {
 					{
 						label: 'Takedown Date',
 						fieldname: 'takedown_date',
-						fieldtype: 'Date',
+						type: 'date',
+						default: this.$site.doc.takedown_date || '',
 						description:
 							'The site will be suspended on this date. Leave empty to remove the scheduled takedown.'
 					}
 				],
-				initialValues: {
-					takedown_date: this.$site.doc.takedown_date || ''
-				},
-				onSuccess: ({ data: values }) => {
+				onSuccess: ({ values }) => {
 					this.$site.setTakedownDate.submit({
 						date: values.takedown_date || null
 					});

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -68,7 +68,8 @@ export default {
 		unlock: 'unlock_for_termination',
 		lock: 'lock_for_protection',
 		dropSite: 'drop_site',
-		updateSite: 'update_site'
+		updateSite: 'update_site',
+		setTakedownDate: 'set_takedown_date'
 	},
 	list: {
 		route: '/sites',
@@ -1359,6 +1360,31 @@ export default {
 									`${window.location.protocol}//${window.location.host}/app/site/${site.name}`,
 									'_blank'
 								);
+							}
+						},
+						{
+							label: 'Set Takedown Date',
+							icon: 'calendar',
+							condition: () =>
+								$team.doc?.is_desk_user &&
+								['Development', 'Demo'].includes(site.doc?.environment),
+							onClick() {
+								confirmDialog({
+									title: 'Set Takedown Date',
+									fields: [
+										{
+											label: 'Takedown Date',
+											fieldname: 'takedown_date',
+											fieldtype: 'Date',
+											description:
+												'The site will be suspended on this date. Leave empty to remove the scheduled takedown.'
+										}
+									],
+									initialValues: { takedown_date: site.doc.takedown_date || '' },
+									onSuccess({ data: values }) {
+										site.setTakedownDate.submit({ date: values.takedown_date || null });
+									}
+								});
 							}
 						},
 						{

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1375,13 +1375,13 @@ export default {
 										{
 											label: 'Takedown Date',
 											fieldname: 'takedown_date',
-											fieldtype: 'Date',
+											type: 'date',
+											default: site.doc.takedown_date || '',
 											description:
 												'The site will be suspended on this date. Leave empty to remove the scheduled takedown.'
 										}
 									],
-									initialValues: { takedown_date: site.doc.takedown_date || '' },
-									onSuccess({ data: values }) {
+									onSuccess({ values }) {
 										site.setTakedownDate.submit({ date: values.takedown_date || null });
 									}
 								});

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1363,31 +1363,6 @@ export default {
 							}
 						},
 						{
-							label: 'Set Takedown Date',
-							icon: 'calendar',
-							condition: () =>
-								$team.doc?.is_desk_user &&
-								['Development', 'Demo'].includes(site.doc?.environment),
-							onClick() {
-								confirmDialog({
-									title: 'Set Takedown Date',
-									fields: [
-										{
-											label: 'Takedown Date',
-											fieldname: 'takedown_date',
-											type: 'date',
-											default: site.doc.takedown_date || '',
-											description:
-												'The site will be suspended on this date. Leave empty to remove the scheduled takedown.'
-										}
-									],
-									onSuccess({ values }) {
-										site.setTakedownDate.submit({ date: values.takedown_date || null });
-									}
-								});
-							}
-						},
-						{
 							label: 'Login As Administrator',
 							icon: 'external-link',
 							condition: () => site.doc.status === 'Active',

--- a/dashboard/src2/pages/NewSite.vue
+++ b/dashboard/src2/pages/NewSite.vue
@@ -448,6 +448,17 @@
 					</div>
 				</div>
 			</div>
+			<div v-if="plan && cluster && ['Development', 'Demo'].includes(environment)">
+				<div class="text-sm font-medium text-gray-700 mb-1">Takedown Date (Optional)</div>
+				<FormControl
+					type="date"
+					v-model="takedownDate"
+					placeholder="No automatic takedown"
+				/>
+				<p class="text-xs text-gray-500 mt-1">
+					If set, the site will be suspended on this date and permanently deleted after the grace period.
+				</p>
+			</div>
 			<Summary
 				v-if="cluster && plan && companyName"
 				:options="siteSummaryOptions"
@@ -540,6 +551,7 @@ export default {
 			companyNameAbbr: '',
 			showModal: false,
 			backup: this.backup,
+			takedownDate: null,
 		};
 	},
 	watch: {
@@ -585,8 +597,11 @@ export default {
 		closestCluster() {
 			this.cluster = this.closestCluster;
 		},
-		environment() {
-			this.tenancy = this.getDefaultTenancy(this.environment);
+		environment(val) {
+			this.tenancy = this.getDefaultTenancy(val);
+			if (val === 'Production') {
+				this.takedownDate = null;
+			}
 		},
 		projectName: {
 			handler: debounce(function (value) {
@@ -686,6 +701,7 @@ export default {
 							tenancy: this.tenancy,
 							site_plan: this.plan.name,
 							backup: this.backup,
+							takedown_date: this.takedownDate || null,
 						}
 					};
 				},
@@ -974,8 +990,12 @@ export default {
 					label: 'Total',
 					value: `${this.totalPerMonth} per month <div class="text-gray-600">${this.totalPerDay} per day</div>`,
 					condition: () => this._totalPerMonth
+				},
+				this.takedownDate && {
+					label: 'Takedown Date',
+					value: this.takedownDate,
 				}
-			];
+			].filter(Boolean);
 		}
 	},
 	methods: {

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -42,6 +42,11 @@ def _new(args):
     site_plan = args.get("site_plan")
     backup = args.get("backup")
 
+    takedown_date = args.get("takedown_date")
+
+    if takedown_date and environment == "Production":
+        frappe.throw("Temporary sites are not allowed for Production environments")
+
     team = frappe.db.get_value("Team", {"team_title": "DevOps"}, "name")
     site_plan_details = get_site_plan_details(site_plan)
     domain = frappe.db.get_value("Root Domain", {"environment": environment}, "name")
@@ -81,7 +86,7 @@ def _new(args):
         created["bench"] = bench
 
         print("Creating site")
-        site = create_site(company_name, company_name_abbr, bench, product, tenancy, release_group, cluster, app_server, project_name, team, domain, site_plan, backup)
+        site = create_site(company_name, company_name_abbr, bench, product, tenancy, release_group, cluster, app_server, project_name, team, domain, site_plan, backup, takedown_date)
         created["site"] = site.name
 
         create_notification({
@@ -322,7 +327,7 @@ def create_deploy_candidate(release_group):
     return deploy_candidate.name
 
 
-def create_site(company_name, company_name_abbr, bench_name, product, tenancy, release_group, cluster_name, app_server_name, project_name, team, domain, site_plan, backup):
+def create_site(company_name, company_name_abbr, bench_name, product, tenancy, release_group, cluster_name, app_server_name, project_name, team, domain, site_plan, backup, takedown_date=None):
     bench_doc = frappe.get_doc("Bench", bench_name)
     bench_apps = [{"app": app.app} for app in bench_doc.apps]
 
@@ -346,6 +351,7 @@ def create_site(company_name, company_name_abbr, bench_name, product, tenancy, r
         "apps": bench_apps,
         "plan": site_plan,
         "restored_from_backup": backup,
+        "takedown_date": takedown_date,
     })
     site_doc.insert()
     frappe.db.commit()

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -192,6 +192,9 @@ scheduler_events = {
 		"press.press.doctype.site_domain.site_domain.update_dns_type",
 		"press.press.doctype.press_webhook_log.press_webhook_log.clean_logs_older_than_24_hours",
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_all_snapshots_from_aws",
+		"press.press.doctype.site.bizkit_archive.notify_upcoming_takedowns",
+		"press.press.doctype.site.bizkit_archive.suspend_temporary_sites",
+		"press.press.doctype.site.bizkit_archive.archive_expired_temporary_sites",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",

--- a/press/playbooks/roles/terminate_rds/tasks/main.yml
+++ b/press/playbooks/roles/terminate_rds/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Disable RDS deletion protection
+  amazon.aws.rds_instance:
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    db_instance_identifier: '{{ instance_abbr }}-db'
+    state: present
+    deletion_protection: false
+    region: ap-southeast-1
+
 - name: Delete RDS instance
   amazon.aws.rds_instance:
     aws_access_key: '{{ ec2_access_key }}'
@@ -7,7 +16,6 @@
     state: absent
     skip_final_snapshot: true
     region: ap-southeast-1
-  ignore_errors: true
 
 - name: Delete RDS subnet group
   amazon.aws.rds_subnet_group:
@@ -16,7 +24,6 @@
     name: '{{ instance_abbr }}-db'
     state: absent
     region: ap-southeast-1
-  ignore_errors: true
 
 - name: Delete RDS security group
   amazon.aws.ec2_security_group:
@@ -26,4 +33,3 @@
     state: absent
     region: ap-southeast-1
   when: security_group_id | length > 0
-  ignore_errors: true

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -886,6 +886,12 @@ class Cluster(Document):
 				self.subnet_2_cidr_block = "10.0.1.0/24"
 			else:
 				self.status = "Pending"
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("VPC Setup Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			self.status = "Pending"
 			log_error("VPC Setup Exception", server=self.as_dict())
@@ -914,6 +920,11 @@ class Cluster(Document):
 			)
 			play = ansible.run()
 			if play.status != "Success":
-				log_error("VPC Deletion Failed", server=self.as_dict())
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("VPC Deletion Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			log_error("VPC Deletion Exception", server=self.as_dict())

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -94,7 +94,8 @@
   "column_break_objb",
   "stalk_interval",
   "stalk_cycles",
-  "stalk_sleep"
+  "stalk_sleep",
+  "allow_auto_delete"
  ],
  "fields": [
   {
@@ -497,6 +498,12 @@
    "fieldname": "stalk_sleep",
    "fieldtype": "Int",
    "label": "Stalk Sleep"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_auto_delete",
+   "fieldtype": "Check",
+   "label": "Allow Auto Delete"
   },
   {
    "default": "0",

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -20,6 +20,7 @@
   "is_server_prepared",
   "is_server_renamed",
   "public",
+  "allow_auto_delete",
   "instance_details_sb",
   "instance_type",
   "column_break_blsz",
@@ -94,8 +95,7 @@
   "column_break_objb",
   "stalk_interval",
   "stalk_cycles",
-  "stalk_sleep",
-  "allow_auto_delete"
+  "stalk_sleep"
  ],
  "fields": [
   {
@@ -501,6 +501,7 @@
   },
   {
    "default": "1",
+   "description": "Allow automatic deletion during temporary site teardown. Disabled automatically when a Production server is linked.",
    "fieldname": "allow_auto_delete",
    "fieldtype": "Check",
    "label": "Allow Auto Delete"
@@ -648,7 +649,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-30 21:02:44.163676",
+ "modified": "2026-06-19 19:28:07.582721",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -403,6 +403,12 @@ class DatabaseServer(BaseServer):
 				self.process_hybrid_server_setup()
 			else:
 				self.status = "Broken"
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("Database Server Setup Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			self.status = "Broken"
 			log_error("Database Server Setup Exception", server=self.as_dict())

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -32,6 +32,7 @@ class DatabaseServer(BaseServer):
 		from press.press.doctype.server_mount.server_mount import ServerMount
 
 		agent_password: DF.Password | None
+		allow_auto_delete: DF.Check
 		auto_add_storage_max: DF.Int
 		auto_add_storage_min: DF.Int
 		backup_retention_period: DF.Int

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -193,6 +193,8 @@
   "telegram_alerts_chat_group",
   "maintenance_section",
   "server_manager_role",
+  "temporary_site_grace_period_days",
+  "temporary_site_warning_days",
   "feature_flags_tab",
   "verify_cards_with_micro_charge",
   "enable_google_oauth",
@@ -1347,6 +1349,18 @@
    "fieldtype": "Link",
    "label": "Server Manager Role",
    "options": "Role"
+  },
+  {
+   "default": "7",
+   "fieldname": "temporary_site_grace_period_days",
+   "fieldtype": "Int",
+   "label": "Temporary Site Grace Period (Days)"
+  },
+  {
+   "default": "3",
+   "fieldname": "temporary_site_warning_days",
+   "fieldtype": "Int",
+   "label": "Temporary Site Warning Days"
   }
  ],
  "issingle": 1,

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -193,8 +193,8 @@
   "telegram_alerts_chat_group",
   "maintenance_section",
   "server_manager_role",
-  "temporary_site_grace_period_days",
   "temporary_site_warning_days",
+  "temporary_site_grace_period_days",
   "feature_flags_tab",
   "verify_cards_with_micro_charge",
   "enable_google_oauth",
@@ -1352,12 +1352,14 @@
   },
   {
    "default": "7",
+   "description": "Number of days after the site takedown date before a suspended temporary site is permanently deleted",
    "fieldname": "temporary_site_grace_period_days",
    "fieldtype": "Int",
    "label": "Temporary Site Grace Period (Days)"
   },
   {
    "default": "3",
+   "description": "Number of days before the site takedown date to send a suspension warning notification",
    "fieldname": "temporary_site_warning_days",
    "fieldtype": "Int",
    "label": "Temporary Site Warning Days"
@@ -1365,7 +1367,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-04-07 19:02:13.302422",
+ "modified": "2026-06-19 19:45:24.443315",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -144,6 +144,8 @@ class PressSettings(Document):
 		telegram_alerts_chat_group: DF.Link | None
 		telegram_bot_token: DF.Data | None
 		telegram_chat_id: DF.Data | None
+		temporary_site_grace_period_days: DF.Int
+		temporary_site_warning_days: DF.Int
 		threshold: DF.Float
 		tls_renewal_queue_size: DF.Int
 		trial_sites_count: DF.Int

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1557,6 +1557,12 @@ class Server(BaseServer):
 				self.security_group = instance["security_groups"][0]["group_id"]
 			else:
 				self.status = "Broken"
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("Server Setup Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			self.status = "Broken"
 			log_error("Server Setup Exception", server=self.as_dict())
@@ -1610,7 +1616,12 @@ class Server(BaseServer):
 				db_doc.security_group = db_doc.security_group + f',{task_result["group_id"]}'
 				db_doc.save()
 			else:
-				log_error("EC2 to RDS Connection Exception", server=self.as_dict())
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("EC2 to RDS Connection Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			log_error("EC2 to RDS Connection Exception", server=self.as_dict())
 		self.save()
@@ -2177,7 +2188,12 @@ class Server(BaseServer):
 					"Database Server", self.database_server, "security_group", rds_security_groups.join(",")
 				)
 			else:
-				log_error("Instance Termination Failed", server=self.as_dict())
+				failed_tasks = frappe.get_all(
+					"Ansible Task",
+					filters={"play": play.name, "status": "Failure"},
+					fields=["task", "error", "exception"],
+				)
+				log_error("Instance Termination Error", server=self.name, tasks=failed_tasks)
 		except Exception:
 			log_error("Instance Termination Exception", server=self.as_dict())
 		self.save()

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1384,6 +1384,9 @@ class Server(BaseServer):
 			if database_server_public != self.public:
 				frappe.db.set_value("Database Server", self.database_server, "public", self.public)
 
+			if self.environment == "Production":
+				frappe.db.set_value("Database Server", self.database_server, "allow_auto_delete", 0)
+
 		if not self.is_new() and self.has_value_changed("team"):
 			self.update_subscription()
 			frappe.db.delete("Press Role Permission", {"server": self.name})

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -185,7 +185,6 @@ def teardown_temporary_site(site_doc):
 				f"allow_auto_delete is disabled. Manual cleanup required."
 			)
 			return
-		db_doc.disable_termination_protection()
 		db_doc.terminate_instance()
 		force_delete("Database Server", db_server_name)
 

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -178,6 +178,13 @@ def teardown_temporary_site(site_doc):
 	remaining = frappe.db.count("Server", {"cluster": cluster_name, "status": ("!=", "Archived")})
 	if remaining == 0 and db_server_name:
 		db_doc = frappe.get_doc("Database Server", db_server_name)
+		if not db_doc.allow_auto_delete:
+			db_doc.add_comment(
+				"Comment",
+				f"Temporary site teardown skipped auto-deletion of this Database Server because "
+				f"allow_auto_delete is disabled. Manual cleanup required."
+			)
+			return
 		db_doc.disable_termination_protection()
 		db_doc.terminate_instance()
 		force_delete("Database Server", db_server_name)

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import add_to_date, today
+from frappe.utils import add_to_date, get_url, today
 from press.api.bizkit_site import force_delete
 
 
@@ -73,15 +73,26 @@ def notify_upcoming_takedowns():
 	for site in sites:
 		try:
 			archive_date = add_to_date(site.takedown_date, days=grace_period)
-			body = (
-				f"Your site {site.name} is scheduled to be suspended on {site.takedown_date}. "
-				f"It will be permanently deleted on {archive_date}."
+			site_url = get_url(f"/dashboard/sites/{site.name}")
+			notification_body = (
+				f"Your site {site.name} is scheduled to be suspended on {site.takedown_date} "
+				f"and will be permanently deleted on {archive_date}. "
+				f"To extend the takedown date, visit the site dashboard: {site_url}"
 			)
-			_create_notification(site.team, site.name, "Site Scheduled for Suspension", body)
+			email_body = (
+				f"Your site <strong>{site.name}</strong> is scheduled to be suspended on "
+				f"<strong>{site.takedown_date}</strong> and will be permanently deleted on "
+				f"<strong>{archive_date}</strong>.<br><br>"
+				f"If you need more time, a System Manager can extend the takedown date from the "
+				f"<a href='{site_url}'>site dashboard</a> using the <em>Set Takedown Date</em> action.<br><br>"
+				f"<strong>Please note:</strong> Keeping this site running beyond its scheduled takedown "
+				f"date incurs additional infrastructure costs. Any extension must be approved before proceeding."
+			)
+			_create_notification(site.team, site.name, "Site Scheduled for Suspension", notification_body)
 			_send_email(
 				_get_email_recipients(site.name),
 				f"[Press] Site {site.name} scheduled for suspension on {site.takedown_date}",
-				body,
+				email_body,
 			)
 		except Exception:
 			frappe.log_error("Temporary Site: notify_upcoming_takedowns failed", site.name)

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -9,6 +9,31 @@ def _get_settings():
 	return grace_period, warning_days
 
 
+def _get_email_recipients(site_name):
+	creator_email = frappe.db.get_value("Site", site_name, "owner")
+	sysmanager_emails = frappe.db.sql_list("""
+		SELECT DISTINCT u.email
+		FROM `tabHas Role` hr
+		JOIN `tabUser` u ON u.name = hr.parent
+		WHERE hr.role = 'System Manager'
+		  AND hr.parenttype = 'User'
+		  AND u.enabled = 1
+	""")
+	recipients = list(({creator_email} | set(sysmanager_emails)) - {None, ""})
+	return recipients
+
+
+def _send_email(recipients, subject, message):
+	if not recipients:
+		return
+	frappe.sendmail(
+		recipients=recipients,
+		subject=subject,
+		message=message,
+		now=True,
+	)
+
+
 def _create_notification(team, site_name, title, message):
 	notification_doc = frappe.get_doc({
 		"doctype": "Press Notification",
@@ -48,11 +73,15 @@ def notify_upcoming_takedowns():
 	for site in sites:
 		try:
 			archive_date = add_to_date(site.takedown_date, days=grace_period)
-			_create_notification(
-				site.team, site.name,
-				"Site Scheduled for Suspension",
+			body = (
 				f"Your site {site.name} is scheduled to be suspended on {site.takedown_date}. "
 				f"It will be permanently deleted on {archive_date}."
+			)
+			_create_notification(site.team, site.name, "Site Scheduled for Suspension", body)
+			_send_email(
+				_get_email_recipients(site.name),
+				f"[Press] Site {site.name} scheduled for suspension on {site.takedown_date}",
+				body,
 			)
 		except Exception:
 			frappe.log_error("Temporary Site: notify_upcoming_takedowns failed", site.name)
@@ -72,10 +101,12 @@ def suspend_temporary_sites():
 			frappe.get_doc("Server", site.server).stop_instance()
 			frappe.db.commit()
 			archive_date = add_to_date(site.takedown_date, days=grace_period)
-			_create_notification(
-				site.team, site.name,
-				"Site Suspended",
-				f"Site {site.name} has been suspended and will be permanently deleted on {archive_date}."
+			body = f"Site {site.name} has been suspended and will be permanently deleted on {archive_date}."
+			_create_notification(site.team, site.name, "Site Suspended", body)
+			_send_email(
+				_get_email_recipients(site.name),
+				f"[Press] Site {site.name} has been suspended",
+				body,
 			)
 		except Exception:
 			frappe.db.rollback()
@@ -93,11 +124,13 @@ def archive_expired_temporary_sites():
 	for site in sites:
 		try:
 			site_doc = frappe.get_doc("Site", site.name)
+			recipients = _get_email_recipients(site.name)
 			teardown_temporary_site(site_doc)
-			_create_notification(
-				site.team, site.name,
-				"Site Permanently Deleted",
-				f"Site {site.name} and its infrastructure have been permanently deleted."
+			body = f"Site {site.name} and its infrastructure have been permanently deleted."
+			_send_email(
+				recipients,
+				f"[Press] Site {site.name} has been permanently deleted",
+				body,
 			)
 		except Exception:
 			frappe.log_error("Temporary Site: archive_expired_temporary_sites failed", site.name)

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.utils import add_to_date, today
+from press.api.bizkit_site import force_delete
 
 
 def _get_settings():
@@ -77,6 +78,7 @@ def suspend_temporary_sites():
 				f"Site {site.name} has been suspended and will be permanently deleted on {archive_date}."
 			)
 		except Exception:
+			frappe.db.rollback()
 			frappe.log_error("Temporary Site: suspend_temporary_sites failed", site.name)
 
 
@@ -85,7 +87,7 @@ def archive_expired_temporary_sites():
 
 	sites = _get_temporary_sites(f"""
 		AND s.status = 'Inactive'
-		AND DATE_ADD(s.takedown_date, INTERVAL {grace_period} DAY) <= '{today()}'
+		AND DATE_ADD(s.takedown_date, INTERVAL {int(grace_period)} DAY) <= '{today()}'
 	""")
 
 	for site in sites:
@@ -102,8 +104,6 @@ def archive_expired_temporary_sites():
 
 
 def teardown_temporary_site(site_doc):
-	from press.api.bizkit_site import force_delete
-
 	cluster_name = site_doc.cluster
 	server_name = site_doc.server
 	bench_name = site_doc.bench

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -84,7 +84,7 @@ def notify_upcoming_takedowns():
 				f"<strong>{site.takedown_date}</strong> and will be permanently deleted on "
 				f"<strong>{archive_date}</strong>.<br><br>"
 				f"If you need more time, a System Manager can extend the takedown date from the "
-				f"<a href='{site_url}'>site dashboard</a> using the <em>Set Takedown Date</em> action.<br><br>"
+				f"<strong><a href='{site_url}'>site dashboard</a></strong> using the <em>Set Takedown Date</em> action.<br><br>"
 				f"<strong>Please note:</strong> Keeping this site running beyond its scheduled takedown "
 				f"date incurs additional infrastructure costs. Any extension must be approved before proceeding."
 			)

--- a/press/press/doctype/site/bizkit_archive.py
+++ b/press/press/doctype/site/bizkit_archive.py
@@ -1,0 +1,143 @@
+import frappe
+from frappe.utils import add_to_date, today
+
+
+def _get_settings():
+	grace_period = frappe.db.get_single_value("Press Settings", "temporary_site_grace_period_days") or 7
+	warning_days = frappe.db.get_single_value("Press Settings", "temporary_site_warning_days") or 3
+	return grace_period, warning_days
+
+
+def _create_notification(team, site_name, title, message):
+	notification_doc = frappe.get_doc({
+		"doctype": "Press Notification",
+		"team": team,
+		"type": "Site Update",
+		"document_type": "Site",
+		"document_name": site_name,
+		"class": "Info",
+		"title": title,
+		"message": message,
+	})
+	notification_doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	frappe.publish_realtime("press_notification", doctype="Press Notification", message={"team": team})
+
+
+def _get_temporary_sites(extra_filters=""):
+	"""Return sites with takedown_date set, on Development or Demo servers."""
+	return frappe.db.sql("""
+		SELECT s.name, s.team, s.server, s.status, s.takedown_date
+		FROM `tabSite` s
+		JOIN `tabServer` srv ON srv.name = s.server
+		WHERE s.takedown_date IS NOT NULL
+		  AND srv.environment IN ('Development', 'Demo')
+		""" + extra_filters, as_dict=True)
+
+
+def notify_upcoming_takedowns():
+	grace_period, warning_days = _get_settings()
+	warning_date = add_to_date(today(), days=warning_days)
+
+	sites = _get_temporary_sites(f"""
+		AND s.takedown_date = '{warning_date}'
+		AND s.status NOT IN ('Inactive', 'Archived')
+	""")
+
+	for site in sites:
+		try:
+			archive_date = add_to_date(site.takedown_date, days=grace_period)
+			_create_notification(
+				site.team, site.name,
+				"Site Scheduled for Suspension",
+				f"Your site {site.name} is scheduled to be suspended on {site.takedown_date}. "
+				f"It will be permanently deleted on {archive_date}."
+			)
+		except Exception:
+			frappe.log_error("Temporary Site: notify_upcoming_takedowns failed", site.name)
+
+
+def suspend_temporary_sites():
+	grace_period, _ = _get_settings()
+
+	sites = _get_temporary_sites(f"""
+		AND s.takedown_date = '{today()}'
+		AND s.status NOT IN ('Inactive', 'Archived')
+	""")
+
+	for site in sites:
+		try:
+			frappe.db.set_value("Site", site.name, "status", "Inactive")
+			frappe.get_doc("Server", site.server).stop_instance()
+			frappe.db.commit()
+			archive_date = add_to_date(site.takedown_date, days=grace_period)
+			_create_notification(
+				site.team, site.name,
+				"Site Suspended",
+				f"Site {site.name} has been suspended and will be permanently deleted on {archive_date}."
+			)
+		except Exception:
+			frappe.log_error("Temporary Site: suspend_temporary_sites failed", site.name)
+
+
+def archive_expired_temporary_sites():
+	grace_period, _ = _get_settings()
+
+	sites = _get_temporary_sites(f"""
+		AND s.status = 'Inactive'
+		AND DATE_ADD(s.takedown_date, INTERVAL {grace_period} DAY) <= '{today()}'
+	""")
+
+	for site in sites:
+		try:
+			site_doc = frappe.get_doc("Site", site.name)
+			teardown_temporary_site(site_doc)
+			_create_notification(
+				site.team, site.name,
+				"Site Permanently Deleted",
+				f"Site {site.name} and its infrastructure have been permanently deleted."
+			)
+		except Exception:
+			frappe.log_error("Temporary Site: archive_expired_temporary_sites failed", site.name)
+
+
+def teardown_temporary_site(site_doc):
+	from press.api.bizkit_site import force_delete
+
+	cluster_name = site_doc.cluster
+	server_name = site_doc.server
+	bench_name = site_doc.bench
+	release_group = site_doc.release_group
+
+	# Get the DB server before we delete anything
+	db_server_name = frappe.db.get_value("Server", server_name, "database_server")
+
+	# 1. Delete site and linked docs
+	force_delete("Site", site_doc.name)
+
+	# 2. Delete bench and linked docs
+	force_delete("Bench", bench_name)
+
+	# 3. Delete release group server entry (not the whole RG — just remove this server)
+	rg_doc = frappe.get_doc("Release Group", release_group)
+	rg_doc.servers = [s for s in rg_doc.servers if s.server != server_name]
+	rg_doc.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	# 4. Terminate app server
+	server_doc = frappe.get_doc("Server", server_name)
+	server_doc.disable_termination_protection()
+	server_doc.terminate_instance()
+	force_delete("Server", server_name)
+
+	# 5. If no other active servers in this cluster, tear down DB server + cluster
+	remaining = frappe.db.count("Server", {"cluster": cluster_name, "status": ("!=", "Archived")})
+	if remaining == 0 and db_server_name:
+		db_doc = frappe.get_doc("Database Server", db_server_name)
+		db_doc.disable_termination_protection()
+		db_doc.terminate_instance()
+		force_delete("Database Server", db_server_name)
+
+		cluster_doc = frappe.get_doc("Cluster", cluster_name)
+		cluster_doc.delete_vpc()
+		force_delete("Cluster", cluster_name)

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -24,6 +24,7 @@
   "cluster",
   "admin_password",
   "additional_system_user_created",
+  "takedown_date",
   "config_tab",
   "hide_config",
   "host_name",
@@ -645,6 +646,7 @@
    "read_only": 1
   },
   {
+   "description": "Date this site will be automatically suspended. Only applies to Development and Demo environments. Leave empty for no scheduled takedown.",
    "fieldname": "takedown_date",
    "fieldtype": "Date",
    "label": "Takedown Date"
@@ -742,7 +744,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2025-12-05 19:16:24.163152",
+ "modified": "2026-06-19 19:42:49.994446",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -645,6 +645,11 @@
    "read_only": 1
   },
   {
+   "fieldname": "takedown_date",
+   "fieldtype": "Date",
+   "label": "Takedown Date"
+  },
+  {
    "depends_on": "eval:doc.update_trigger_frequency === 'Every 2 Weeks'",
    "fieldname": "update_start_date",
    "fieldtype": "Date",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -182,6 +182,7 @@ class Site(Document, TagHelpers):
 		status_before_update: DF.Data | None
 		subdomain: DF.Data
 		tags: DF.Table[ResourceTag]
+		takedown_date: DF.Date | None
 		team: DF.Link
 		tenancy: DF.Literal["Dedicated", "Shared"]
 		timezone: DF.Data | None

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2837,6 +2837,15 @@ class Site(Document, TagHelpers):
 
 		return [d for d in actions if d.get("condition", True)]
 
+	@frappe.whitelist()
+	def set_takedown_date(self, date=None):
+		frappe.only_for("System Manager")
+		environment = frappe.db.get_value("Server", self.server, "environment")
+		if date and environment == "Production":
+			frappe.throw("Temporary sites are not allowed for Production environments")
+		self.takedown_date = date
+		self.save(ignore_permissions=True)
+
 	@property
 	def hybrid_site(self) -> bool:
 		return bool(frappe.get_cached_value("Server", self.server, "is_self_hosted"))

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2837,7 +2837,7 @@ class Site(Document, TagHelpers):
 
 		return [d for d in actions if d.get("condition", True)]
 
-	@frappe.whitelist()
+	@dashboard_whitelist()
 	def set_takedown_date(self, date=None):
 		frappe.only_for("System Manager")
 		environment = frappe.db.get_value("Server", self.server, "environment")

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -220,7 +220,8 @@ class Site(Document, TagHelpers):
 		"update_trigger_time",
 		"additional_system_user_created",
 		"domain",
-		"site_url"
+		"site_url",
+		"takedown_date"
 	)
 
 	@staticmethod
@@ -286,11 +287,12 @@ class Site(Document, TagHelpers):
 		)
 		doc.update_information = self.get_update_information()
 		doc.actions = self.get_actions()
-		server = frappe.get_value("Server", self.server, ["ip", "proxy_server", "team", "title"], as_dict=1)
+		server = frappe.get_value("Server", self.server, ["ip", "proxy_server", "team", "title", "environment"], as_dict=1)
 		doc.cluster = frappe.db.get_value("Cluster", self.cluster, ["title", "image"], as_dict=1)
 		doc.outbound_ip = server.ip
 		doc.server_team = server.team
 		doc.server_title = server.title
+		doc.environment = server.environment
 		doc.inbound_ip = self.inbound_ip
 		doc.is_dedicated_server = is_dedicated_server(self.server)
 

--- a/press/press/doctype/site/test_bizkit_archive.py
+++ b/press/press/doctype/site/test_bizkit_archive.py
@@ -1,0 +1,196 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+from frappe.utils import add_to_date, today
+
+
+class TestNotifyUpcomingTakedowns(unittest.TestCase):
+
+	@patch("press.press.doctype.site.bizkit_archive._create_notification")
+	@patch("press.press.doctype.site.bizkit_archive._get_temporary_sites")
+	@patch("press.press.doctype.site.bizkit_archive._get_settings")
+	def test_sends_notification_for_sites_due_for_warning(self, mock_settings, mock_get_sites, mock_notify):
+		mock_settings.return_value = (7, 3)
+		mock_get_sites.return_value = [
+			{"name": "site1.example.com", "team": "team1", "server": "srv1",
+			 "status": "Active", "takedown_date": add_to_date(today(), days=3)}
+		]
+
+		from press.press.doctype.site.bizkit_archive import notify_upcoming_takedowns
+		notify_upcoming_takedowns()
+
+		mock_notify.assert_called_once()
+		args = mock_notify.call_args[0]
+		assert args[1] == "site1.example.com"
+		assert "suspended" in args[3].lower()
+
+	@patch("press.press.doctype.site.bizkit_archive._create_notification")
+	@patch("press.press.doctype.site.bizkit_archive._get_temporary_sites")
+	@patch("press.press.doctype.site.bizkit_archive._get_settings")
+	def test_skips_inactive_sites(self, mock_settings, mock_get_sites, mock_notify):
+		mock_settings.return_value = (7, 3)
+		mock_get_sites.return_value = []  # SQL filter already excludes Inactive
+
+		from press.press.doctype.site.bizkit_archive import notify_upcoming_takedowns
+		notify_upcoming_takedowns()
+
+		mock_notify.assert_not_called()
+
+	@patch("frappe.log_error")
+	@patch("press.press.doctype.site.bizkit_archive._create_notification")
+	@patch("press.press.doctype.site.bizkit_archive._get_temporary_sites")
+	@patch("press.press.doctype.site.bizkit_archive._get_settings")
+	def test_logs_error_and_continues_on_failure(self, mock_settings, mock_get_sites, mock_notify, mock_log_error):
+		mock_settings.return_value = (7, 3)
+		mock_get_sites.return_value = [
+			{"name": "site1.example.com", "team": "team1", "server": "srv1",
+			 "status": "Active", "takedown_date": add_to_date(today(), days=3)},
+			{"name": "site2.example.com", "team": "team2", "server": "srv2",
+			 "status": "Active", "takedown_date": add_to_date(today(), days=3)},
+		]
+		mock_notify.side_effect = [Exception("DB error"), None]
+
+		from press.press.doctype.site.bizkit_archive import notify_upcoming_takedowns
+		notify_upcoming_takedowns()
+
+		mock_log_error.assert_called_once()
+		assert mock_notify.call_count == 2  # attempted both sites
+
+
+class TestSuspendTemporarySites(unittest.TestCase):
+
+	@patch("press.press.doctype.site.bizkit_archive._create_notification")
+	@patch("frappe.get_doc")
+	@patch("frappe.db")
+	@patch("press.press.doctype.site.bizkit_archive._get_temporary_sites")
+	@patch("press.press.doctype.site.bizkit_archive._get_settings")
+	def test_sets_status_inactive_and_stops_instance(self, mock_settings, mock_get_sites, mock_db, mock_get_doc, mock_notify):
+		mock_settings.return_value = (7, 3)
+		mock_get_sites.return_value = [
+			{"name": "site1.example.com", "team": "team1", "server": "srv1",
+			 "status": "Active", "takedown_date": today()}
+		]
+		mock_server = MagicMock()
+		mock_get_doc.return_value = mock_server
+
+		from press.press.doctype.site.bizkit_archive import suspend_temporary_sites
+		suspend_temporary_sites()
+
+		mock_db.set_value.assert_called_with("Site", "site1.example.com", "status", "Inactive")
+		mock_server.stop_instance.assert_called_once()
+		mock_notify.assert_called_once()
+
+
+class TestArchiveExpiredTemporarySites(unittest.TestCase):
+
+	@patch("press.press.doctype.site.bizkit_archive._create_notification")
+	@patch("press.press.doctype.site.bizkit_archive.teardown_temporary_site")
+	@patch("frappe.get_doc")
+	@patch("press.press.doctype.site.bizkit_archive._get_temporary_sites")
+	@patch("press.press.doctype.site.bizkit_archive._get_settings")
+	def test_calls_teardown_for_expired_sites(self, mock_settings, mock_get_sites, mock_get_doc, mock_teardown, mock_notify):
+		mock_settings.return_value = (7, 3)
+		mock_get_sites.return_value = [
+			{"name": "site1.example.com", "team": "team1", "server": "srv1",
+			 "status": "Inactive", "takedown_date": add_to_date(today(), days=-8)}
+		]
+		mock_site_doc = MagicMock()
+		mock_get_doc.return_value = mock_site_doc
+
+		from press.press.doctype.site.bizkit_archive import archive_expired_temporary_sites
+		archive_expired_temporary_sites()
+
+		mock_teardown.assert_called_once_with(mock_site_doc)
+		mock_notify.assert_called_once()
+
+
+class TestTeardownTemporarySite(unittest.TestCase):
+
+	@patch("press.press.doctype.site.bizkit_archive.force_delete")
+	@patch("frappe.db")
+	@patch("frappe.get_doc")
+	def test_deletes_site_bench_server_and_cluster_when_last_server(self, mock_get_doc, mock_db, mock_force_delete):
+		# Setup site_doc mock
+		site_doc = MagicMock()
+		site_doc.name = "site1.example.com"
+		site_doc.cluster = "cluster1"
+		site_doc.server = "srv1"
+		site_doc.bench = "bench1"
+		site_doc.release_group = "rg1"
+
+		# db.get_value returns db_server, db.count returns 0 (last server)
+		mock_db.get_value.return_value = "db-srv1"
+		mock_db.count.return_value = 0
+
+		mock_server = MagicMock()
+		mock_db_server = MagicMock()
+		mock_cluster = MagicMock()
+		mock_rg = MagicMock()
+		mock_rg.servers = []
+
+		def get_doc_side_effect(doctype, name=None):
+			if doctype == "Server":
+				return mock_server
+			if doctype == "Database Server":
+				return mock_db_server
+			if doctype == "Cluster":
+				return mock_cluster
+			if doctype == "Release Group":
+				return mock_rg
+			return MagicMock()
+
+		mock_get_doc.side_effect = get_doc_side_effect
+
+		from press.press.doctype.site.bizkit_archive import teardown_temporary_site
+		teardown_temporary_site(site_doc)
+
+		# Site and bench deleted
+		mock_force_delete.assert_any_call("Site", "site1.example.com")
+		mock_force_delete.assert_any_call("Bench", "bench1")
+		# Server terminated and deleted
+		mock_server.terminate_instance.assert_called_once()
+		mock_force_delete.assert_any_call("Server", "srv1")
+		# DB server terminated and deleted (last server)
+		mock_db_server.terminate_instance.assert_called_once()
+		mock_force_delete.assert_any_call("Database Server", "db-srv1")
+		# Cluster VPC deleted
+		mock_cluster.delete_vpc.assert_called_once()
+		mock_force_delete.assert_any_call("Cluster", "cluster1")
+
+	@patch("press.press.doctype.site.bizkit_archive.force_delete")
+	@patch("frappe.db")
+	@patch("frappe.get_doc")
+	def test_skips_cluster_teardown_when_other_servers_remain(self, mock_get_doc, mock_db, mock_force_delete):
+		site_doc = MagicMock()
+		site_doc.name = "site1.example.com"
+		site_doc.cluster = "cluster1"
+		site_doc.server = "srv1"
+		site_doc.bench = "bench1"
+		site_doc.release_group = "rg1"
+
+		mock_db.get_value.return_value = "db-srv1"
+		mock_db.count.return_value = 1  # another server still exists
+
+		mock_server = MagicMock()
+		mock_rg = MagicMock()
+		mock_rg.servers = []
+
+		def get_doc_side_effect(doctype, name=None):
+			if doctype == "Server":
+				return mock_server
+			if doctype == "Release Group":
+				return mock_rg
+			return MagicMock()
+
+		mock_get_doc.side_effect = get_doc_side_effect
+
+		from press.press.doctype.site.bizkit_archive import teardown_temporary_site
+		teardown_temporary_site(site_doc)
+
+		# DB server and cluster should NOT be deleted
+		calls = [str(c) for c in mock_force_delete.call_args_list]
+		assert not any("Database Server" in c for c in calls)
+		assert not any("Cluster" in c for c in calls)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This PR introduces a **temporary site lifecycle management system** for sites running on Development and Demo servers. The goal is to prevent infrastructure cost sprawl by automatically reclaiming short-lived sites (e.g. demos, dev environments) after a scheduled date.

When a site is created with a `takedown_date`, a scheduler-driven pipeline takes over: it sends advance warning notifications, suspends the site on the takedown date, then fully tears down all associated infrastructure (site, bench, app server, database server, cluster/VPC) after a configurable grace period. At every stage, the site owner and all System Managers are notified by email and in-app notification. System Managers can extend the takedown date at any point from the site dashboard.

---

- Adds a `takedown_date` field to the Site doctype, allowing sites on Development/Demo servers to be marked for automatic teardown
- Implements a full scheduler-driven lifecycle: warning notifications → grace period → auto-archive, controlled by configurable settings in Press Settings (`temporary_site_grace_period_days`, `temporary_site_warning_days`)
- Adds dashboard UI for setting/changing the takedown date on new site creation and from the Site Overview tab, with role-based access (System Managers only)
- Adds email and Press Notification alerts for upcoming and executed takedowns, with an "extend" link and cost approval note
- Adds an `allow_auto_delete` safety gate on Database Server to prevent accidental teardown of protected servers
- Fixes RDS termination: disables deletion protection before terminating, improves error logging with failed Ansible task details across RDS, EC2, and VPC flows