### PR TITLE
feat: Site Instance Scheduler

### DIFF
--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -80,6 +80,11 @@
 				</div>
 			</div>
 		</div>
+		<SiteScheduleCard
+			v-if="isSchedulable"
+			:site="site"
+			class="col-span-1 lg:col-span-2"
+		/>
 		<SiteDailyUsage :site="site" />
 		<div class="col-span-1 rounded-md border lg:col-span-2">
 			<div class="grid grid-cols-2 lg:grid-cols-4">
@@ -263,12 +268,13 @@ import { getToastErrorMessage } from '../utils/toast';
 import { confirmDialog, renderDialog } from '../utils/components';
 import SiteDailyUsage from './SiteDailyUsage.vue';
 import AlertBanner from './AlertBanner.vue';
+import SiteScheduleCard from './site/SiteScheduleCard.vue';
 import { trialDays } from '../utils/site';
 
 export default {
 	name: 'SiteOverview',
 	props: ['site'],
-	components: { SiteDailyUsage, Progress, AlertBanner, DismissableBanner },
+	components: { SiteDailyUsage, Progress, AlertBanner, DismissableBanner, SiteScheduleCard },
 	data() {
 		return {
 			isSetupWizardComplete: true
@@ -346,6 +352,9 @@ export default {
 		trialDays
 	},
 	computed: {
+		isSchedulable() {
+			return ['Development', 'Demo'].includes(this.$site.doc?.environment);
+		},
 		siteInformation() {
 			return [
 				{

--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -80,12 +80,11 @@
 				</div>
 			</div>
 		</div>
+		<SiteDailyUsage :site="site" />
 		<SiteScheduleCard
 			v-if="isSchedulable"
 			:site="site"
-			class="col-span-1 lg:col-span-2"
 		/>
-		<SiteDailyUsage :site="site" />
 		<div class="col-span-1 rounded-md border lg:col-span-2">
 			<div class="grid grid-cols-2 lg:grid-cols-4">
 				<div class="border-b border-r p-5 lg:border-b-0">

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -205,6 +205,19 @@ export default {
 				}
 			);
 		},
+		clearSchedule() {
+			toast.promise(
+				this.$site.clearSchedule.submit({ schedule_name: this.schedule.name }),
+				{
+					loading: 'Clearing schedule...',
+					success: () => {
+						this.schedule = null;
+						return 'Schedule cleared';
+					},
+					error: e => getToastErrorMessage(e),
+				}
+			);
+		},
 		_presetDescription(p) {
 			if (!p) return '';
 			const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
@@ -274,11 +287,10 @@ export default {
 					onClick: () => this.showSetScheduleDialog(this.schedule?.preset),
 				},
 				{
-					label: 'Disable Schedule',
-					condition: () => this.schedule?.enabled,
-					onClick: () => this.toggleEnabled(),
+					label: 'Clear Schedule',
+					onClick: () => this.clearSchedule(),
 				},
-			].filter(o => (o.condition ? o.condition() : true));
+			];
 		},
 	},
 };

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -76,6 +76,7 @@ import { toast } from 'vue-sonner';
 import { confirmDialog } from '../../utils/components';
 import { getToastErrorMessage } from '../../utils/toast';
 import dayjs from '../../utils/dayjs';
+import { getTeam } from '../../data/team';
 
 export default {
 	name: 'SiteScheduleCard',
@@ -217,6 +218,9 @@ export default {
 	computed: {
 		$site() {
 			return getCachedDocumentResource('Site', this.site);
+		},
+		$team() {
+			return getTeam();
 		},
 		presetSummary() {
 			const p = this.schedule?.preset_doc;

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -1,0 +1,274 @@
+<!-- dashboard/src2/components/site/SiteScheduleCard.vue -->
+<template>
+	<div class="rounded-md border">
+		<div class="flex h-12 items-center justify-between border-b px-5">
+			<h2 class="text-lg font-medium text-gray-900">Instance Schedule</h2>
+			<div class="flex items-center space-x-2">
+				<template v-if="schedule">
+					<Button
+						:variant="schedule.enabled ? 'solid' : 'outline'"
+						size="sm"
+						@click="toggleEnabled"
+						:loading="$site.setSchedule.loading || $site.disableSchedule.loading"
+					>
+						{{ schedule.enabled ? 'Enabled' : 'Disabled' }}
+					</Button>
+					<Dropdown v-if="$team?.doc?.is_desk_user" :options="menuOptions">
+						<Button variant="ghost" icon="more-horizontal" />
+					</Dropdown>
+				</template>
+				<Button v-else variant="outline" size="sm" @click="showSetScheduleDialog">
+					Set Schedule
+				</Button>
+			</div>
+		</div>
+		<div class="px-5 py-4">
+			<template v-if="!schedule">
+				<p class="text-sm text-gray-500">No schedule configured. Site runs 24/7.</p>
+			</template>
+			<template v-else>
+				<div class="flex items-start justify-between">
+					<div>
+						<p class="font-medium text-gray-900">{{ schedule.preset }}</p>
+						<p class="mt-0.5 text-sm text-gray-500">{{ presetSummary }}</p>
+					</div>
+					<Dropdown
+						v-if="schedule.enabled && schedule.override === 'None'"
+						:options="overrideOptions"
+					>
+						<Button variant="outline" size="sm">
+							Override
+							<template #suffix>
+								<i-lucide-chevron-down class="h-3 w-3" />
+							</template>
+						</Button>
+					</Dropdown>
+				</div>
+				<div
+					v-if="schedule.override !== 'None'"
+					class="mt-3 flex items-center justify-between rounded-md bg-yellow-50 px-3 py-2"
+				>
+					<span class="text-sm text-yellow-800">
+						<template v-if="schedule.override === 'Indefinite'">
+							Schedule paused indefinitely
+						</template>
+						<template v-else-if="schedule.override === 'Until Datetime'">
+							Schedule paused until {{ formattedOverrideUntil }}
+						</template>
+					</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						@click="cancelOverride"
+						:loading="$site.setScheduleOverride.loading"
+					>
+						Cancel
+					</Button>
+				</div>
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import { getCachedDocumentResource, createResource, Button, Dropdown } from 'frappe-ui';
+import { toast } from 'vue-sonner';
+import { confirmDialog } from '../../utils/components';
+import { getToastErrorMessage } from '../../utils/toast';
+import dayjs from '../../utils/dayjs';
+
+export default {
+	name: 'SiteScheduleCard',
+	props: ['site'],
+	components: { Button, Dropdown },
+	data() {
+		return {
+			schedule: null,
+			presetsResource: createResource({
+				url: 'press.api.client.get_list',
+				params: {
+					doctype: 'Site Schedule Preset',
+					fields: ['preset_name'],
+					limit: 50,
+				},
+				auto: true,
+			}),
+		};
+	},
+	mounted() {
+		this.loadSchedule();
+	},
+	methods: {
+		async loadSchedule() {
+			const result = await this.$site.getSchedule.submit();
+			this.schedule = result;
+		},
+		showSetScheduleDialog(currentPreset = null) {
+			const presets = (this.presetsResource.data || []).map(p => p.preset_name);
+			confirmDialog({
+				title: currentPreset ? 'Change Schedule Preset' : 'Set Instance Schedule',
+				fields: [
+					{
+						label: 'Preset',
+						fieldname: 'preset',
+						fieldtype: 'Select',
+						options: presets.join('\n'),
+						default: currentPreset || presets[0] || '',
+					},
+				],
+				onSuccess: ({ values }) => {
+					toast.promise(
+						this.$site.setSchedule.submit({ preset: values.preset }),
+						{
+							loading: 'Saving schedule...',
+							success: () => {
+								this.loadSchedule();
+								return 'Schedule saved';
+							},
+							error: e => getToastErrorMessage(e),
+						}
+					);
+				},
+			});
+		},
+		toggleEnabled() {
+			if (this.schedule?.enabled) {
+				toast.promise(
+					this.$site.disableSchedule.submit(),
+					{
+						loading: 'Disabling schedule...',
+						success: () => {
+							this.loadSchedule();
+							return 'Schedule disabled';
+						},
+						error: e => getToastErrorMessage(e),
+					}
+				);
+			} else {
+				toast.promise(
+					this.$site.setSchedule.submit({ preset: this.schedule.preset }),
+					{
+						loading: 'Enabling schedule...',
+						success: () => {
+							this.loadSchedule();
+							return 'Schedule enabled';
+						},
+						error: e => getToastErrorMessage(e),
+					}
+				);
+			}
+		},
+		showKeepRunningUntilDialog() {
+			confirmDialog({
+				title: 'Keep Running Until',
+				fields: [
+					{
+						label: 'Keep running until',
+						fieldname: 'override_until',
+						fieldtype: 'Datetime',
+					},
+				],
+				onSuccess: ({ values }) => {
+					if (!values.override_until) return;
+					toast.promise(
+						this.$site.setScheduleOverride.submit({
+							override_type: 'Until Datetime',
+							override_until: values.override_until,
+						}),
+						{
+							loading: 'Setting override...',
+							success: () => {
+								this.loadSchedule();
+								return 'Override set';
+							},
+							error: e => getToastErrorMessage(e),
+						}
+					);
+				},
+			});
+		},
+		setIndefiniteOverride() {
+			toast.promise(
+				this.$site.setScheduleOverride.submit({ override_type: 'Indefinite' }),
+				{
+					loading: 'Pausing schedule...',
+					success: () => {
+						this.loadSchedule();
+						return 'Schedule paused';
+					},
+					error: e => getToastErrorMessage(e),
+				}
+			);
+		},
+		cancelOverride() {
+			toast.promise(
+				this.$site.setScheduleOverride.submit({ override_type: 'None' }),
+				{
+					loading: 'Resuming schedule...',
+					success: () => {
+						this.loadSchedule();
+						return 'Schedule resumed';
+					},
+					error: e => getToastErrorMessage(e),
+				}
+			);
+		},
+	},
+	computed: {
+		$site() {
+			return getCachedDocumentResource('Site', this.site);
+		},
+		presetSummary() {
+			const p = this.schedule?.preset_doc;
+			if (!p) return '';
+			const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+			const dayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+			const activeDays = days
+				.map((d, i) => (p[d] ? dayLabels[i] : null))
+				.filter(Boolean);
+
+			const dayStr = activeDays.join(', ');
+			if (p.all_day) return `${dayStr} · All day`;
+
+			const fmt = t => {
+				if (!t) return '';
+				const [h, m] = String(t).split(':');
+				const hour = parseInt(h);
+				const suffix = hour >= 12 ? 'pm' : 'am';
+				const displayHour = hour % 12 || 12;
+				return `${displayHour}:${m}${suffix}`;
+			};
+			return `${dayStr} · ${fmt(p.start_time)} – ${fmt(p.stop_time)}`;
+		},
+		formattedOverrideUntil() {
+			if (!this.schedule?.override_until) return '';
+			return dayjs(this.schedule.override_until).format('MMM D, h:mma');
+		},
+		overrideOptions() {
+			return [
+				{
+					label: 'Keep running until…',
+					onClick: () => this.showKeepRunningUntilDialog(),
+				},
+				{
+					label: 'Run until I turn it back on',
+					onClick: () => this.setIndefiniteOverride(),
+				},
+			];
+		},
+		menuOptions() {
+			return [
+				{
+					label: 'Change Preset',
+					onClick: () => this.showSetScheduleDialog(this.schedule?.preset),
+				},
+				{
+					label: 'Disable Schedule',
+					condition: () => this.schedule?.enabled,
+					onClick: () => this.toggleEnabled(),
+				},
+			].filter(o => (o.condition ? o.condition() : true));
+		},
+	},
+};
+</script>

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -167,7 +167,7 @@ export default {
 					{
 						label: 'Keep running until',
 						fieldname: 'override_until',
-						fieldtype: 'Datetime',
+						type: 'datetime-local',
 					},
 				],
 				onSuccess: ({ values }) => {

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -26,6 +26,9 @@
 			<template v-if="!schedule">
 				<p class="text-sm text-gray-500">No schedule configured. Site runs 24/7.</p>
 			</template>
+			<template v-else-if="!schedule.enabled">
+				<p class="text-sm text-gray-500">Schedule is disabled. Site runs 24/7.</p>
+			</template>
 			<template v-else>
 				<div class="flex items-start justify-between">
 					<div>

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -104,8 +104,8 @@ export default {
 	},
 	methods: {
 		async loadSchedule() {
-			const result = await this.$site.getSchedule.submit();
-			this.schedule = result;
+			await this.$site.getSchedule.submit();
+			this.schedule = this.$site.getSchedule.data?.preset ? this.$site.getSchedule.data : null;
 		},
 		showSetScheduleDialog(currentPreset = null) {
 			confirmDialog({

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -89,7 +89,7 @@ export default {
 				url: 'press.api.client.get_list',
 				params: {
 					doctype: 'Site Schedule Preset',
-					fields: ['preset_name'],
+					fields: ['preset_name', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'all_day', 'start_time', 'stop_time'],
 					limit: 50,
 				},
 				auto: true,
@@ -105,21 +105,22 @@ export default {
 			this.schedule = result;
 		},
 		showSetScheduleDialog(currentPreset = null) {
-			const presets = (this.presetsResource.data || []).map(p => p.preset_name);
 			confirmDialog({
 				title: currentPreset ? 'Change Schedule Preset' : 'Set Instance Schedule',
 				fields: [
 					{
 						label: 'Preset',
 						fieldname: 'preset',
-						fieldtype: 'Select',
-						options: presets.join('\n'),
-						default: currentPreset || presets[0] || '',
+						type: 'autocomplete',
+						options: this.presetOptions,
+						default: currentPreset || (this.presetOptions[0]?.value ?? ''),
 					},
 				],
 				onSuccess: ({ values }) => {
+					const preset = values.preset?.value ?? values.preset;
+					if (!preset) return;
 					toast.promise(
-						this.$site.setSchedule.submit({ preset: values.preset }),
+						this.$site.setSchedule.submit({ preset }),
 						{
 							loading: 'Saving schedule...',
 							success: () => {
@@ -201,6 +202,21 @@ export default {
 				}
 			);
 		},
+		_presetDescription(p) {
+			if (!p) return '';
+			const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+			const dayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+			const activeDays = days.map((d, i) => (p[d] ? dayLabels[i] : null)).filter(Boolean);
+			const dayStr = activeDays.join(', ');
+			if (p.all_day) return `${dayStr} · All day`;
+			const fmt = t => {
+				if (!t) return '';
+				const [h, m] = String(t).split(':');
+				const hour = parseInt(h);
+				return `${hour % 12 || 12}:${m}${hour >= 12 ? 'pm' : 'am'}`;
+			};
+			return `${dayStr} · ${fmt(p.start_time)} – ${fmt(p.stop_time)}`;
+		},
 		cancelOverride() {
 			toast.promise(
 				this.$site.setScheduleOverride.submit({ override_type: 'None' }),
@@ -222,27 +238,15 @@ export default {
 		$team() {
 			return getTeam();
 		},
+		presetOptions() {
+			return (this.presetsResource.data || []).map(p => ({
+				label: p.preset_name,
+				description: this._presetDescription(p),
+				value: p.preset_name,
+			}));
+		},
 		presetSummary() {
-			const p = this.schedule?.preset_doc;
-			if (!p) return '';
-			const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
-			const dayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-			const activeDays = days
-				.map((d, i) => (p[d] ? dayLabels[i] : null))
-				.filter(Boolean);
-
-			const dayStr = activeDays.join(', ');
-			if (p.all_day) return `${dayStr} · All day`;
-
-			const fmt = t => {
-				if (!t) return '';
-				const [h, m] = String(t).split(':');
-				const hour = parseInt(h);
-				const suffix = hour >= 12 ? 'pm' : 'am';
-				const displayHour = hour % 12 || 12;
-				return `${displayHour}:${m}${suffix}`;
-			};
-			return `${dayStr} · ${fmt(p.start_time)} – ${fmt(p.stop_time)}`;
+			return this._presetDescription(this.schedule?.preset_doc);
 		},
 		formattedOverrideUntil() {
 			if (!this.schedule?.override_until) return '';

--- a/dashboard/src2/components/site/SiteScheduleCard.vue
+++ b/dashboard/src2/components/site/SiteScheduleCard.vue
@@ -150,17 +150,7 @@ export default {
 					}
 				);
 			} else {
-				toast.promise(
-					this.$site.setSchedule.submit({ preset: this.schedule.preset }),
-					{
-						loading: 'Enabling schedule...',
-						success: () => {
-							this.loadSchedule();
-							return 'Schedule enabled';
-						},
-						error: e => getToastErrorMessage(e),
-					}
-				);
+				this.showSetScheduleDialog(this.schedule?.preset);
 			}
 		},
 		showKeepRunningUntilDialog() {

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -69,7 +69,11 @@ export default {
 		lock: 'lock_for_protection',
 		dropSite: 'drop_site',
 		updateSite: 'update_site',
-		setTakedownDate: 'set_takedown_date'
+		setTakedownDate: 'set_takedown_date',
+		setSchedule: 'set_schedule',
+		disableSchedule: 'disable_schedule',
+		setScheduleOverride: 'set_schedule_override',
+		getSchedule: 'get_schedule'
 	},
 	list: {
 		route: '/sites',

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -73,7 +73,8 @@ export default {
 		setSchedule: 'set_schedule',
 		disableSchedule: 'disable_schedule',
 		setScheduleOverride: 'set_schedule_override',
-		getSchedule: 'get_schedule'
+		getSchedule: 'get_schedule',
+		clearSchedule: 'clear_schedule'
 	},
 	list: {
 		route: '/sites',

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -89,7 +89,8 @@ export default {
 			'group.version as version',
 			'cluster.image as cluster_image',
 			'cluster.title as cluster_title',
-			'trial_end_date'
+			'trial_end_date',
+			'server.instance_state as server_instance_state'
 		],
 		orderBy: 'creation desc',
 		searchField: 'host_name',
@@ -147,6 +148,7 @@ export default {
 				}
 			},
 			{ label: 'Status', fieldname: 'status', type: 'Badge', width: '140px' },
+			{ label: 'Instance State', fieldname: 'server_instance_state', type: 'Badge', width: '140px' },
 			{
 				label: 'Plan',
 				fieldname: 'plan',
@@ -198,7 +200,10 @@ export default {
 		titleField: 'name',
 		route: '/sites/:name',
 		statusBadge({ documentResource: site }) {
-			return { label: site.doc.status };
+			return [
+				{ label: site.doc.status },
+				{ label: site.doc.server_instance_state }
+			];
 		},
 		breadcrumbs({ items, documentResource: site }) {
 			let breadcrumbs = [];

--- a/dashboard/src2/pages/DetailPage.vue
+++ b/dashboard/src2/pages/DetailPage.vue
@@ -3,18 +3,21 @@
 		<div class="w-full sm:flex sm:items-center sm:justify-between">
 			<div class="flex items-center space-x-2">
 				<FBreadcrumbs :items="breadcrumbs" />
-				<Badge
-					class="hidden sm:inline-flex"
-					v-if="$resources.document?.doc && badge"
-					v-bind="badge"
-				/>
+				<template v-if="$resources.document?.doc && badges.length">
+					<Badge
+						v-for="b in badges"
+						:key="b.label"
+						class="hidden sm:inline-flex"
+						v-bind="b"
+					/>
+				</template>
 			</div>
 			<div
 				class="mt-1 flex items-center justify-between space-x-2 sm:mt-0"
 				v-if="$resources.document?.doc"
 			>
-				<div class="sm:hidden">
-					<Badge v-if="$resources.document?.doc && badge" v-bind="badge" />
+				<div class="sm:hidden flex items-center space-x-1">
+					<Badge v-for="b in badges" :key="b.label" v-bind="b" />
 				</div>
 				<div class="space-x-2">
 					<ActionButton
@@ -134,13 +137,12 @@ export default {
 			let doc = this.$resources.document?.doc;
 			return doc ? doc[this.object.detail.titleField || 'name'] : this.name;
 		},
-		badge() {
-			if (this.object.detail.statusBadge) {
-				return this.object.detail.statusBadge({
-					documentResource: this.$resources.document
-				});
-			}
-			return null;
+		badges() {
+			if (!this.object.detail.statusBadge) return [];
+			const result = this.object.detail.statusBadge({
+				documentResource: this.$resources.document
+			});
+			return (Array.isArray(result) ? result : [result]).filter(b => b?.label);
 		},
 		actions() {
 			if (this.object.detail.actions && this.$resources.document?.doc) {

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -30,6 +30,7 @@ ALLOWED_DOCTYPES = [
 	"Site Plan",
 	"Site Update",
 	"Site Group Deploy",
+	"Site Schedule Preset",
 	"Invoice",
 	"Balance Transaction",
 	"Stripe Payment Method",

--- a/press/fixtures/site_schedule_preset.json
+++ b/press/fixtures/site_schedule_preset.json
@@ -1,0 +1,38 @@
+[
+  {
+    "doctype": "Site Schedule Preset",
+    "preset_name": "Business Hours",
+    "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
+    "saturday": 0, "sunday": 0,
+    "all_day": 0,
+    "start_time": "08:00:00",
+    "stop_time": "18:00:00"
+  },
+  {
+    "doctype": "Site Schedule Preset",
+    "preset_name": "Development Hours",
+    "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
+    "saturday": 0, "sunday": 0,
+    "all_day": 0,
+    "start_time": "07:00:00",
+    "stop_time": "23:59:00"
+  },
+  {
+    "doctype": "Site Schedule Preset",
+    "preset_name": "Weekdays Only",
+    "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
+    "saturday": 0, "sunday": 0,
+    "all_day": 1,
+    "start_time": null,
+    "stop_time": null
+  },
+  {
+    "doctype": "Site Schedule Preset",
+    "preset_name": "Always On",
+    "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
+    "saturday": 1, "sunday": 1,
+    "all_day": 1,
+    "start_time": null,
+    "stop_time": null
+  }
+]

--- a/press/fixtures/site_schedule_preset.json
+++ b/press/fixtures/site_schedule_preset.json
@@ -1,6 +1,7 @@
 [
   {
     "doctype": "Site Schedule Preset",
+    "name": "Business Hours",
     "preset_name": "Business Hours",
     "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
     "saturday": 0, "sunday": 0,
@@ -10,6 +11,7 @@
   },
   {
     "doctype": "Site Schedule Preset",
+    "name": "Development Hours",
     "preset_name": "Development Hours",
     "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
     "saturday": 0, "sunday": 0,
@@ -19,6 +21,7 @@
   },
   {
     "doctype": "Site Schedule Preset",
+    "name": "Weekdays Only",
     "preset_name": "Weekdays Only",
     "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
     "saturday": 0, "sunday": 0,
@@ -28,6 +31,7 @@
   },
   {
     "doctype": "Site Schedule Preset",
+    "name": "Always On",
     "preset_name": "Always On",
     "monday": 1, "tuesday": 1, "wednesday": 1, "thursday": 1, "friday": 1,
     "saturday": 1, "sunday": 1,

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -252,7 +252,10 @@ scheduler_events = {
 			"press.press.doctype.server.server.cleanup_unused_files",
 			"press.press.doctype.razorpay_payment_record.razorpay_payment_record.fetch_pending_payment_orders",
 		],
-		"30 * * * *": ["press.press.doctype.agent_job.agent_job.suspend_sites"],
+		"30 * * * *": [
+			"press.press.doctype.agent_job.agent_job.suspend_sites",
+			"press.press.doctype.site.site_schedule.run_site_schedules",
+		],
 		"*/15 * * * *": [
 			"press.press.doctype.site_update.site_update.schedule_updates",
 			"press.press.doctype.drip_email.drip_email.send_welcome_email",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -322,6 +322,7 @@ fixtures = [
 	"Bench Dependency",
 	"Server Storage Plan",
 	"Press Webhook Event",
+	"Site Schedule Preset",
 ]
 # Testing
 # -------

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -252,10 +252,7 @@ scheduler_events = {
 			"press.press.doctype.server.server.cleanup_unused_files",
 			"press.press.doctype.razorpay_payment_record.razorpay_payment_record.fetch_pending_payment_orders",
 		],
-		"30 * * * *": [
-			"press.press.doctype.agent_job.agent_job.suspend_sites",
-			"press.press.doctype.site.site_schedule.run_site_schedules",
-		],
+		"30 * * * *": ["press.press.doctype.agent_job.agent_job.suspend_sites"],
 		"*/15 * * * *": [
 			"press.press.doctype.site_update.site_update.schedule_updates",
 			"press.press.doctype.drip_email.drip_email.send_welcome_email",
@@ -286,6 +283,7 @@ scheduler_events = {
 		"*/30 * * * *": [
 			"press.press.doctype.site_update.scheduled_auto_updates.trigger",
 			"press.press.doctype.team.suspend_sites.execute",
+			"press.press.doctype.site.site_schedule.run_site_schedules",
 		],
 		"15,45 * * * *": [
 			"press.press.doctype.site.site_usages.update_cpu_usages",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -38,6 +38,7 @@ class BaseServer(Document, TagHelpers):
 		"plan",
 		"cluster",
 		"status",
+		"instance_state",
 		"team",
 		"database_server",
 		"is_self_hosted",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2874,6 +2874,10 @@ class Site(Document, TagHelpers):
 			frappe.db.set_value("Site Schedule", existing, "enabled", 0)
 
 	@dashboard_whitelist()
+	def clear_schedule(self, schedule_name):
+		frappe.delete_doc("Site Schedule", schedule_name, ignore_permissions=True)
+
+	@dashboard_whitelist()
 	def set_schedule_override(self, override_type, override_until=None):
 		if override_type not in ("None", "Until Datetime", "Indefinite"):
 			frappe.throw(f"Invalid override type: {override_type}")

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2847,6 +2847,71 @@ class Site(Document, TagHelpers):
 		self.takedown_date = date
 		self.save(ignore_permissions=True)
 
+	@dashboard_whitelist()
+	def set_schedule(self, preset):
+		environment = frappe.db.get_value("Server", self.server, "environment")
+		if environment == "Production":
+			frappe.throw("Instance scheduling is not available for Production sites")
+		if not frappe.db.exists("Site Schedule Preset", preset):
+			frappe.throw(f"Preset '{preset}' does not exist")
+
+		existing = frappe.db.get_value("Site Schedule", {"site": self.name}, "name")
+		if existing:
+			frappe.db.set_value("Site Schedule", existing, {"preset": preset, "enabled": 1})
+		else:
+			frappe.get_doc({
+				"doctype": "Site Schedule",
+				"site": self.name,
+				"enabled": 1,
+				"preset": preset,
+				"override": "None",
+			}).insert(ignore_permissions=True)
+
+	@dashboard_whitelist()
+	def disable_schedule(self):
+		existing = frappe.db.get_value("Site Schedule", {"site": self.name}, "name")
+		if existing:
+			frappe.db.set_value("Site Schedule", existing, "enabled", 0)
+
+	@dashboard_whitelist()
+	def set_schedule_override(self, override_type, override_until=None):
+		if override_type not in ("None", "Until Datetime", "Indefinite"):
+			frappe.throw(f"Invalid override type: {override_type}")
+		if override_type == "Until Datetime":
+			if not override_until:
+				frappe.throw("override_until is required for 'Until Datetime' override")
+			if get_datetime(override_until) <= now_datetime():
+				frappe.throw("override_until must be a future datetime")
+		existing = frappe.db.get_value("Site Schedule", {"site": self.name}, "name")
+		if not existing:
+			frappe.throw("No schedule exists for this site. Set a schedule first.")
+		frappe.db.set_value("Site Schedule", existing, {
+			"override": override_type,
+			"override_until": override_until if override_type == "Until Datetime" else None,
+		})
+
+	@dashboard_whitelist()
+	def get_schedule(self):
+		schedule_name = frappe.db.get_value("Site Schedule", {"site": self.name}, "name")
+		if not schedule_name:
+			return None
+		schedule = frappe.db.get_value(
+			"Site Schedule",
+			schedule_name,
+			["name", "enabled", "preset", "override", "override_until"],
+			as_dict=True,
+		)
+		if schedule and schedule.preset:
+			preset = frappe.db.get_value(
+				"Site Schedule Preset",
+				schedule.preset,
+				["preset_name", "monday", "tuesday", "wednesday", "thursday",
+				 "friday", "saturday", "sunday", "all_day", "start_time", "stop_time"],
+				as_dict=True,
+			)
+			schedule.preset_doc = preset
+		return schedule
+
 	@property
 	def hybrid_site(self) -> bool:
 		return bool(frappe.get_cached_value("Server", self.server, "is_self_hosted"))

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -288,12 +288,13 @@ class Site(Document, TagHelpers):
 		)
 		doc.update_information = self.get_update_information()
 		doc.actions = self.get_actions()
-		server = frappe.get_value("Server", self.server, ["ip", "proxy_server", "team", "title", "environment"], as_dict=1)
+		server = frappe.get_value("Server", self.server, ["ip", "proxy_server", "team", "title", "environment", "instance_state"], as_dict=1)
 		doc.cluster = frappe.db.get_value("Cluster", self.cluster, ["title", "image"], as_dict=1)
 		doc.outbound_ip = server.ip
 		doc.server_team = server.team
 		doc.server_title = server.title
 		doc.environment = server.environment
+		doc.server_instance_state = server.instance_state
 		doc.inbound_ip = self.inbound_ip
 		doc.is_dedicated_server = is_dedicated_server(self.server)
 

--- a/press/press/doctype/site/site_schedule.py
+++ b/press/press/doctype/site/site_schedule.py
@@ -30,7 +30,7 @@ def _process_schedule(schedule):
         return
 
     server = frappe.db.get_value(
-        "Server", site.server, ["environment", "status"], as_dict=True
+        "Server", site.server, ["environment", "status", "instance_state"], as_dict=True
     )
     if not server or server.environment not in ("Development", "Demo"):
         return
@@ -47,7 +47,7 @@ def _process_schedule(schedule):
         frappe.db.commit()
 
     desired_up = _should_be_up(schedule, local_now, on_override_clear)
-    actual_up = server.status == "Active"
+    actual_up = server.instance_state == "Running"
 
     if desired_up and not actual_up:
         frappe.get_doc("Server", site.server).start_instance()

--- a/press/press/doctype/site/site_schedule.py
+++ b/press/press/doctype/site/site_schedule.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytz
+import frappe
+from frappe.utils import get_datetime, now_datetime, get_system_timezone
+
+from press.press.doctype.site_activity.site_activity import log_site_activity
+
+_DAY_FIELDS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+
+
+def run_site_schedules():
+    schedules = frappe.get_all(
+        "Site Schedule",
+        filters={"enabled": 1},
+        fields=["name", "site", "preset", "override", "override_until"],
+    )
+    for schedule in schedules:
+        try:
+            _process_schedule(schedule)
+        except Exception:
+            frappe.log_error(f"Site Schedule failed for {schedule.site}")
+
+
+def _process_schedule(schedule):
+    site = frappe.db.get_value(
+        "Site", schedule.site, ["server", "status"], as_dict=True
+    )
+    if not site or site.status == "Archived":
+        return
+
+    server = frappe.db.get_value(
+        "Server", site.server, ["environment", "status"], as_dict=True
+    )
+    if not server or server.environment not in ("Development", "Demo"):
+        return
+
+    tz = pytz.timezone(get_system_timezone())
+    local_now = pytz.utc.localize(now_datetime()).astimezone(tz)
+
+    def on_override_clear():
+        frappe.db.set_value(
+            "Site Schedule",
+            schedule.name,
+            {"override": "None", "override_until": None},
+        )
+        frappe.db.commit()
+
+    desired_up = _should_be_up(schedule, local_now, on_override_clear)
+    actual_up = server.status == "Active"
+
+    if desired_up and not actual_up:
+        frappe.get_doc("Server", site.server).start_instance()
+        log_site_activity(schedule.site, "Schedule Start")
+    elif not desired_up and actual_up:
+        frappe.get_doc("Server", site.server).stop_instance()
+        log_site_activity(schedule.site, "Schedule Stop")
+
+
+def _should_be_up(schedule, local_now, on_override_clear):
+    """
+    Pure(-ish) function: given a schedule and the local current datetime,
+    return True if the site instance should be running.
+
+    on_override_clear is called (with no args) when an expired Until Datetime
+    override is detected and should be cleared.
+    """
+    if schedule.override == "Indefinite":
+        return True
+
+    if schedule.override == "Until Datetime" and schedule.override_until:
+        override_dt = pytz.utc.localize(get_datetime(schedule.override_until))
+        if local_now < override_dt:
+            return True
+        on_override_clear()
+        # Fall through to preset evaluation after clearing
+
+    preset = _get_preset(schedule.preset)
+    if not preset:
+        return True  # No preset found; leave instance running
+
+    day_index = local_now.weekday()  # 0=Monday, 6=Sunday
+    if not getattr(preset, _DAY_FIELDS[day_index], False):
+        return False
+
+    if preset.all_day:
+        return True
+
+    if not preset.start_time or not preset.stop_time:
+        return True
+
+    current = local_now.time().replace(second=0, microsecond=0)
+    start = _parse_time(preset.start_time)
+    stop = _parse_time(preset.stop_time)
+    return start <= current <= stop
+
+
+def _get_preset(preset_name):
+    return frappe.db.get_value(
+        "Site Schedule Preset",
+        preset_name,
+        _DAY_FIELDS + ["all_day", "start_time", "stop_time"],
+        as_dict=True,
+    )
+
+
+def _parse_time(t):
+    """Convert a Frappe time value (string 'HH:MM:SS' or datetime.time) to datetime.time."""
+    from datetime import time as dtime
+    if isinstance(t, dtime):
+        return t.replace(second=0, microsecond=0)
+    h, m, *_ = str(t).split(":")
+    return dtime(int(h), int(m))

--- a/press/press/doctype/site/test_site_schedule.py
+++ b/press/press/doctype/site/test_site_schedule.py
@@ -1,0 +1,97 @@
+import unittest
+from datetime import datetime, time
+from unittest.mock import MagicMock, patch
+
+import pytz
+
+
+class TestShouldBeUp(unittest.TestCase):
+    """Tests for _should_be_up — pure logic, no DB needed."""
+
+    def _make_schedule(self, override="None", override_until=None):
+        s = MagicMock()
+        s.name = "SCHED-001"
+        s.override = override
+        s.override_until = override_until
+        return s
+
+    def _make_preset(self, all_day=False, start="08:00:00", stop="18:00:00",
+                     weekdays_only=True):
+        p = MagicMock()
+        p.monday = p.tuesday = p.wednesday = p.thursday = p.friday = 1 if weekdays_only else 1
+        p.saturday = p.sunday = 0 if weekdays_only else 1
+        p.all_day = all_day
+        p.start_time = start
+        p.stop_time = stop
+        return p
+
+    def _local_dt(self, weekday_offset, hour, minute=0):
+        """Return a Monday + weekday_offset datetime at the given hour."""
+        # 2026-06-22 is a Monday
+        base = datetime(2026, 6, 22 + weekday_offset, hour, minute)
+        return pytz.utc.localize(base)
+
+    def test_indefinite_override_always_up(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule(override="Indefinite")
+        result = _should_be_up(schedule, self._local_dt(0, 2), lambda: None)
+        self.assertTrue(result)
+
+    def test_until_datetime_override_up_before_expiry(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule(
+            override="Until Datetime",
+            override_until="2099-12-31 23:59:59"
+        )
+        result = _should_be_up(schedule, self._local_dt(0, 2), lambda: None)
+        self.assertTrue(result)
+
+    def test_until_datetime_override_clears_when_expired(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        cleared = []
+        schedule = self._make_schedule(
+            override="Until Datetime",
+            override_until="2020-01-01 00:00:00"
+        )
+
+        def on_clear():
+            cleared.append(True)
+
+        with patch("press.press.doctype.site.site_schedule._get_preset") as mock_preset:
+            mock_preset.return_value = self._make_preset(all_day=True)
+            # Monday 10am — within Business Hours after override clears
+            local_now = self._local_dt(0, 10)
+            result = _should_be_up(schedule, local_now, on_clear)
+        self.assertTrue(len(cleared) == 1, "Override clear callback was not called")
+
+    def test_preset_weekday_within_hours_is_up(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule()
+        with patch("press.press.doctype.site.site_schedule._get_preset") as mock_preset:
+            mock_preset.return_value = self._make_preset()
+            result = _should_be_up(schedule, self._local_dt(0, 10), lambda: None)
+        self.assertTrue(result)
+
+    def test_preset_weekday_outside_hours_is_down(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule()
+        with patch("press.press.doctype.site.site_schedule._get_preset") as mock_preset:
+            mock_preset.return_value = self._make_preset()
+            result = _should_be_up(schedule, self._local_dt(0, 1), lambda: None)  # 1am
+        self.assertFalse(result)
+
+    def test_preset_weekend_is_down(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule()
+        with patch("press.press.doctype.site.site_schedule._get_preset") as mock_preset:
+            mock_preset.return_value = self._make_preset(weekdays_only=True)
+            result = _should_be_up(schedule, self._local_dt(5, 10), lambda: None)  # Saturday
+        self.assertFalse(result)
+
+    def test_all_day_preset_active_day_is_up(self):
+        from press.press.doctype.site.site_schedule import _should_be_up
+        schedule = self._make_schedule()
+        with patch("press.press.doctype.site.site_schedule._get_preset") as mock_preset:
+            mock_preset.return_value = self._make_preset(all_day=True)
+            result = _should_be_up(schedule, self._local_dt(0, 3), lambda: None)  # 3am Monday
+        self.assertTrue(result)

--- a/press/press/doctype/site/test_site_schedule_methods.py
+++ b/press/press/doctype/site/test_site_schedule_methods.py
@@ -1,0 +1,94 @@
+import frappe
+import unittest
+from unittest.mock import patch
+
+
+class TestSiteScheduleMethods(unittest.TestCase):
+	def setUp(self):
+		# Create a minimal preset
+		if not frappe.db.exists("Site Schedule Preset", "Test Preset"):
+			frappe.get_doc({
+				"doctype": "Site Schedule Preset",
+				"preset_name": "Test Preset",
+				"monday": 1, "tuesday": 1, "wednesday": 1,
+				"thursday": 1, "friday": 1,
+				"saturday": 0, "sunday": 0,
+				"all_day": 1,
+			}).insert(ignore_permissions=True)
+
+	def _get_dev_site(self):
+		# Get a site on a Development or Demo server
+		site_name = frappe.db.get_value(
+			"Site",
+			{"status": ["in", ["Active", "Inactive"]]},
+			"name",
+			order_by="creation desc"
+		)
+		if not site_name:
+			self.skipTest("No suitable site found for testing")
+		server_env = frappe.db.get_value(
+			"Server",
+			frappe.db.get_value("Site", site_name, "server"),
+			"environment"
+		)
+		if server_env == "Production":
+			self.skipTest("Test site is on Production server — scheduling blocked")
+		return frappe.get_doc("Site", site_name)
+
+	def test_set_schedule_creates_site_schedule(self):
+		site = self._get_dev_site()
+		# Clean up any pre-existing schedule
+		if frappe.db.exists("Site Schedule", {"site": site.name}):
+			frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+
+		site.set_schedule("Test Preset")
+		schedule = frappe.db.get_value("Site Schedule", {"site": site.name}, ["enabled", "preset"], as_dict=True)
+		self.assertIsNotNone(schedule)
+		self.assertEqual(schedule.enabled, 1)
+		self.assertEqual(schedule.preset, "Test Preset")
+		frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+
+	def test_disable_schedule(self):
+		site = self._get_dev_site()
+		site.set_schedule("Test Preset")
+		site.disable_schedule()
+		enabled = frappe.db.get_value("Site Schedule", {"site": site.name}, "enabled")
+		self.assertEqual(enabled, 0)
+		frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+
+	def test_set_schedule_override_indefinite(self):
+		site = self._get_dev_site()
+		site.set_schedule("Test Preset")
+		site.set_schedule_override("Indefinite")
+		override = frappe.db.get_value("Site Schedule", {"site": site.name}, "override")
+		self.assertEqual(override, "Indefinite")
+		frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+
+	def test_set_schedule_override_until_datetime_requires_future_date(self):
+		site = self._get_dev_site()
+		site.set_schedule("Test Preset")
+		with self.assertRaises(frappe.ValidationError):
+			site.set_schedule_override("Until Datetime", "2020-01-01 00:00:00")
+		frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+
+	def test_get_schedule_returns_none_when_no_schedule(self):
+		site = self._get_dev_site()
+		if frappe.db.exists("Site Schedule", {"site": site.name}):
+			frappe.delete_doc("Site Schedule", frappe.db.get_value("Site Schedule", {"site": site.name}), ignore_permissions=True)
+		result = site.get_schedule()
+		self.assertIsNone(result)
+
+	def test_set_schedule_blocked_on_production(self):
+		prod_server = frappe.db.get_value("Server", {"environment": "Production"}, "name")
+		if not prod_server:
+			self.skipTest("No Production server found")
+		prod_site_name = frappe.db.get_value("Site", {"server": prod_server, "status": "Active"}, "name")
+		if not prod_site_name:
+			self.skipTest("No active site on Production server found")
+		site = frappe.get_doc("Site", prod_site_name)
+		with self.assertRaises(frappe.ValidationError):
+			site.set_schedule("Test Preset")
+
+	def tearDown(self):
+		if frappe.db.exists("Site Schedule Preset", "Test Preset"):
+			frappe.delete_doc("Site Schedule Preset", "Test Preset", ignore_permissions=True)

--- a/press/press/doctype/site_activity/site_activity.json
+++ b/press/press/doctype/site_activity/site_activity.json
@@ -29,7 +29,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Action",
-   "options": "Activate Site\nAdd Domain\nArchive\nBackup\nCreate\nClear Cache\nDeactivate Site\nInstall App\nLogin as Administrator\nMigrate\nReinstall\nRestore\nSuspend Site\nUninstall App\nUnsuspend Site\nUpdate\nUpdate Configuration\nDrop Offsite Backups\nEnable Database Access\nDisable Database Access\nCreate Database User\nRemove Database User\nModify Database User Permissions",
+   "options": "Activate Site\nAdd Domain\nArchive\nBackup\nCreate\nClear Cache\nDeactivate Site\nInstall App\nLogin as Administrator\nMigrate\nReinstall\nRestore\nSuspend Site\nUninstall App\nUnsuspend Site\nUpdate\nUpdate Configuration\nDrop Offsite Backups\nEnable Database Access\nDisable Database Access\nCreate Database User\nRemove Database User\nModify Database User Permissions\nSchedule Start\nSchedule Stop",
    "read_only": 1,
    "reqd": 1,
    "search_index": 1

--- a/press/press/doctype/site_schedule/site_schedule.json
+++ b/press/press/doctype/site_schedule/site_schedule.json
@@ -1,0 +1,92 @@
+{
+ "actions": [],
+ "creation": "2026-06-22 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "site",
+  "enabled",
+  "preset",
+  "override_section",
+  "override",
+  "override_until"
+ ],
+ "fields": [
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Site",
+   "options": "Site",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "preset",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Preset",
+   "options": "Site Schedule Preset",
+   "reqd": 1
+  },
+  {
+   "fieldname": "override_section",
+   "fieldtype": "Section Break",
+   "label": "Override"
+  },
+  {
+   "default": "None",
+   "fieldname": "override",
+   "fieldtype": "Select",
+   "label": "Override",
+   "options": "None\nUntil Datetime\nIndefinite"
+  },
+  {
+   "depends_on": "eval:doc.override === 'Until Datetime'",
+   "fieldname": "override_until",
+   "fieldtype": "Datetime",
+   "label": "Override Until"
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-22 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Site Schedule",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "write": 1,
+   "role": "Press Admin"
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "write": 1,
+   "role": "Press Member"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/press/press/doctype/site_schedule/site_schedule.py
+++ b/press/press/doctype/site_schedule/site_schedule.py
@@ -1,0 +1,18 @@
+from frappe.model.document import Document
+
+
+class SiteSchedule(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		site: DF.Link
+		enabled: DF.Check
+		preset: DF.Link
+		override: DF.Literal["None", "Until Datetime", "Indefinite"]
+		override_until: DF.Datetime | None
+	# end: auto-generated types

--- a/press/press/doctype/site_schedule/site_schedule.py
+++ b/press/press/doctype/site_schedule/site_schedule.py
@@ -16,3 +16,4 @@ class SiteSchedule(Document):
 		override: DF.Literal["None", "Until Datetime", "Indefinite"]
 		override_until: DF.Datetime | None
 	# end: auto-generated types
+

--- a/press/press/doctype/site_schedule/test_site_schedule.py
+++ b/press/press/doctype/site_schedule/test_site_schedule.py
@@ -1,0 +1,68 @@
+import frappe
+import unittest
+
+
+class TestSiteSchedule(unittest.TestCase):
+	def setUp(self):
+		self.preset = frappe.get_doc({
+			"doctype": "Site Schedule Preset",
+			"preset_name": "Test Schedule Preset",
+			"monday": 1,
+			"tuesday": 1,
+			"wednesday": 1,
+			"thursday": 1,
+			"friday": 1,
+			"saturday": 0,
+			"sunday": 0,
+			"all_day": 0,
+			"start_time": "08:00:00",
+			"stop_time": "18:00:00",
+		})
+		self.preset.insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.delete_doc("Site Schedule Preset", self.preset.name, ignore_permissions=True)
+
+	def test_site_schedule_creation(self):
+		# Assumes a site named "test.localhost" exists in the test environment
+		schedule = frappe.get_doc({
+			"doctype": "Site Schedule",
+			"site": frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost",
+			"enabled": 1,
+			"preset": self.preset.name,
+			"override": "None",
+		})
+		schedule.insert(ignore_permissions=True)
+		self.assertEqual(schedule.enabled, 1)
+		self.assertEqual(schedule.preset, self.preset.name)
+		self.assertEqual(schedule.override, "None")
+		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)
+
+	def test_override_until_datetime(self):
+		site_name = frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost"
+		schedule = frappe.get_doc({
+			"doctype": "Site Schedule",
+			"site": site_name,
+			"enabled": 1,
+			"preset": self.preset.name,
+			"override": "Until Datetime",
+			"override_until": "2026-12-31 23:59:59",
+		})
+		schedule.insert(ignore_permissions=True)
+		self.assertEqual(schedule.override, "Until Datetime")
+		self.assertIsNotNone(schedule.override_until)
+		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)
+
+	def test_indefinite_override(self):
+		site_name = frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost"
+		schedule = frappe.get_doc({
+			"doctype": "Site Schedule",
+			"site": site_name,
+			"enabled": 0,
+			"preset": self.preset.name,
+			"override": "Indefinite",
+		})
+		schedule.insert(ignore_permissions=True)
+		self.assertEqual(schedule.override, "Indefinite")
+		self.assertEqual(schedule.enabled, 0)
+		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)

--- a/press/press/doctype/site_schedule/test_site_schedule.py
+++ b/press/press/doctype/site_schedule/test_site_schedule.py
@@ -25,21 +25,24 @@ class TestSiteSchedule(unittest.TestCase):
 
 	def test_site_schedule_creation(self):
 		# Assumes a site named "test.localhost" exists in the test environment
+		sites = frappe.get_all("Site", limit=1)
+		site_name = sites[0].name if sites else "test.localhost"
 		schedule = frappe.get_doc({
 			"doctype": "Site Schedule",
-			"site": frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost",
+			"site": site_name,
 			"enabled": 1,
 			"preset": self.preset.name,
 			"override": "None",
 		})
 		schedule.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Site Schedule", schedule.name, ignore_permissions=True)
 		self.assertEqual(schedule.enabled, 1)
 		self.assertEqual(schedule.preset, self.preset.name)
 		self.assertEqual(schedule.override, "None")
-		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)
 
 	def test_override_until_datetime(self):
-		site_name = frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost"
+		sites = frappe.get_all("Site", limit=1)
+		site_name = sites[0].name if sites else "test.localhost"
 		schedule = frappe.get_doc({
 			"doctype": "Site Schedule",
 			"site": site_name,
@@ -49,12 +52,13 @@ class TestSiteSchedule(unittest.TestCase):
 			"override_until": "2026-12-31 23:59:59",
 		})
 		schedule.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Site Schedule", schedule.name, ignore_permissions=True)
 		self.assertEqual(schedule.override, "Until Datetime")
 		self.assertIsNotNone(schedule.override_until)
-		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)
 
 	def test_indefinite_override(self):
-		site_name = frappe.get_all("Site", limit=1)[0].name if frappe.get_all("Site", limit=1) else "test.localhost"
+		sites = frappe.get_all("Site", limit=1)
+		site_name = sites[0].name if sites else "test.localhost"
 		schedule = frappe.get_doc({
 			"doctype": "Site Schedule",
 			"site": site_name,
@@ -63,6 +67,6 @@ class TestSiteSchedule(unittest.TestCase):
 			"override": "Indefinite",
 		})
 		schedule.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Site Schedule", schedule.name, ignore_permissions=True)
 		self.assertEqual(schedule.override, "Indefinite")
 		self.assertEqual(schedule.enabled, 0)
-		frappe.delete_doc("Site Schedule", schedule.name, ignore_permissions=True)

--- a/press/press/doctype/site_schedule_preset/site_schedule_preset.json
+++ b/press/press/doctype/site_schedule_preset/site_schedule_preset.json
@@ -1,0 +1,99 @@
+{
+  "actions": [],
+  "autoname": "field:preset_name",
+  "creation": "2026-06-22 00:00:00.000000",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": [
+    "preset_name",
+    "days_section",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+    "time_section",
+    "all_day",
+    "start_time",
+    "stop_time"
+  ],
+  "fields": [
+    {
+      "fieldname": "preset_name",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Preset Name",
+      "reqd": 1,
+      "unique": 1
+    },
+    {
+      "fieldname": "days_section",
+      "fieldtype": "Section Break",
+      "label": "Active Days"
+    },
+    {"fieldname": "monday",    "fieldtype": "Check", "label": "Monday"},
+    {"fieldname": "tuesday",   "fieldtype": "Check", "label": "Tuesday"},
+    {"fieldname": "wednesday", "fieldtype": "Check", "label": "Wednesday"},
+    {"fieldname": "thursday",  "fieldtype": "Check", "label": "Thursday"},
+    {"fieldname": "friday",    "fieldtype": "Check", "label": "Friday"},
+    {"fieldname": "saturday",  "fieldtype": "Check", "label": "Saturday"},
+    {"fieldname": "sunday",    "fieldtype": "Check", "label": "Sunday"},
+    {
+      "fieldname": "time_section",
+      "fieldtype": "Section Break",
+      "label": "Time Window"
+    },
+    {
+      "fieldname": "all_day",
+      "fieldtype": "Check",
+      "label": "All Day",
+      "description": "If checked, instance runs all day on active days. Start/stop time is ignored."
+    },
+    {
+      "depends_on": "eval:!doc.all_day",
+      "fieldname": "start_time",
+      "fieldtype": "Time",
+      "label": "Start Time"
+    },
+    {
+      "depends_on": "eval:!doc.all_day",
+      "fieldname": "stop_time",
+      "fieldtype": "Time",
+      "label": "Stop Time"
+    }
+  ],
+  "links": [],
+  "modified": "2026-06-22 00:00:00.000000",
+  "modified_by": "Administrator",
+  "module": "Press",
+  "name": "Site Schedule Preset",
+  "naming_rule": "By fieldname",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "read": 1,
+      "role": "Press Admin"
+    },
+    {
+      "read": 1,
+      "role": "Press Member"
+    }
+  ],
+  "sort_field": "preset_name",
+  "sort_order": "ASC",
+  "track_changes": 0
+}

--- a/press/press/doctype/site_schedule_preset/site_schedule_preset.py
+++ b/press/press/doctype/site_schedule_preset/site_schedule_preset.py
@@ -22,3 +22,17 @@ class SiteSchedulePreset(Document):
 		start_time: DF.Time | None
 		stop_time: DF.Time | None
 	# end: auto-generated types
+
+	dashboard_fields = (
+		"preset_name",
+		"monday",
+		"tuesday",
+		"wednesday",
+		"thursday",
+		"friday",
+		"saturday",
+		"sunday",
+		"all_day",
+		"start_time",
+		"stop_time",
+	)

--- a/press/press/doctype/site_schedule_preset/site_schedule_preset.py
+++ b/press/press/doctype/site_schedule_preset/site_schedule_preset.py
@@ -1,0 +1,24 @@
+from frappe.model.document import Document
+
+
+class SiteSchedulePreset(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		preset_name: DF.Data
+		monday: DF.Check
+		tuesday: DF.Check
+		wednesday: DF.Check
+		thursday: DF.Check
+		friday: DF.Check
+		saturday: DF.Check
+		sunday: DF.Check
+		all_day: DF.Check
+		start_time: DF.Time | None
+		stop_time: DF.Time | None
+	# end: auto-generated types

--- a/press/press/doctype/site_schedule_preset/test_site_schedule_preset.py
+++ b/press/press/doctype/site_schedule_preset/test_site_schedule_preset.py
@@ -1,0 +1,37 @@
+import frappe
+import unittest
+
+
+class TestSiteSchedulePreset(unittest.TestCase):
+	def test_preset_creation(self):
+		preset = frappe.get_doc({
+			"doctype": "Site Schedule Preset",
+			"preset_name": "Test Hours",
+			"monday": 1,
+			"tuesday": 1,
+			"wednesday": 0,
+			"thursday": 0,
+			"friday": 0,
+			"saturday": 0,
+			"sunday": 0,
+			"all_day": 0,
+			"start_time": "09:00:00",
+			"stop_time": "17:00:00",
+		})
+		preset.insert(ignore_permissions=True)
+		self.assertEqual(preset.preset_name, "Test Hours")
+		self.assertEqual(preset.monday, 1)
+		self.assertEqual(preset.start_time, "09:00:00")
+		frappe.delete_doc("Site Schedule Preset", preset.name, ignore_permissions=True)
+
+	def test_all_day_preset(self):
+		preset = frappe.get_doc({
+			"doctype": "Site Schedule Preset",
+			"preset_name": "Test All Day",
+			"monday": 1, "tuesday": 1, "wednesday": 1,
+			"thursday": 1, "friday": 1, "saturday": 1, "sunday": 1,
+			"all_day": 1,
+		})
+		preset.insert(ignore_permissions=True)
+		self.assertEqual(preset.all_day, 1)
+		frappe.delete_doc("Site Schedule Preset", preset.name, ignore_permissions=True)


### PR DESCRIPTION
- Adds a **Site Schedule** system that allows teams to automatically start/stop site instances on a defined schedule (cron-based), reducing cloud costs during off-hours
- Adds a **Site Schedule Preset** doctype with default fixtures (e.g. "Business Hours", "Always On") for quick schedule configuration
- Adds a `SiteScheduleCard` UI component to the Site Overview page for Dev/Demo sites, showing current schedule state and letting users set, override, or clear their schedule
- Exposes `set_schedule`, `disable_schedule`, `set_schedule_override`, and `get_schedule` API methods on the `Site` doctype
- Shows a server **instance state badge** (running/stopped) in the site list and detail header, using a new `instance_state` field on `Server`

<img width="695" height="102" alt="image" src="https://github.com/user-attachments/assets/5e7af8c4-2e11-4151-8d4b-07080d6b6472" />

<img width="989" height="195" alt="image" src="https://github.com/user-attachments/assets/dd71bb51-c7be-47e9-9182-9867acdcb098" />
