### PR TITLE
feat: Overhaul site list filters

### DIFF
--- a/dashboard/src2/objects/bench.ts
+++ b/dashboard/src2/objects/bench.ts
@@ -5,7 +5,6 @@ import { defineAsyncComponent, h } from 'vue';
 import { getTeam, switchToTeam } from '../data/team';
 import { icon } from '../utils/components';
 import {
-	clusterOptions,
 	getSitesTabColumns,
 	sitesTabRoute,
 	siteTabFilterControls
@@ -229,10 +228,12 @@ function filterControls() {
 			}
 		},
 		{
-			type: 'select',
-			label: 'Region',
+			type: 'link',
+			label: 'Project',
 			fieldname: 'cluster',
-			options: clusterOptions
+			options: {
+				doctype: 'Cluster'
+			}
 		}
 	] satisfies FilterField[] as FilterField[];
 }

--- a/dashboard/src2/objects/common/index.ts
+++ b/dashboard/src2/objects/common/index.ts
@@ -1,5 +1,4 @@
-import { createListResource } from 'frappe-ui';
-import { defineAsyncComponent, h, reactive } from 'vue';
+import { defineAsyncComponent, h } from 'vue';
 import { renderDialog } from '../../utils/components';
 import type {
 	BannerConfig,
@@ -13,17 +12,6 @@ import { planTitle } from '../../utils/format';
 
 export const unreachable = Error('unreachable'); // used to indicate that a codepath is unreachable
 
-export const clusterOptions: string[] = reactive(['']);
-
-createListResource({
-	doctype: 'Cluster',
-	fields: ['name', 'title'],
-	orderBy: 'title asc',
-	auto: true,
-	onSuccess(data: { name: string }[]) {
-		clusterOptions.splice(0, clusterOptions.length, '', ...data.map(c => c.name));
-	}
-});
 
 export function getUpsellBanner(site: DocumentResource, title: string) {
 	if (
@@ -105,10 +93,12 @@ export function siteTabFilterControls() {
 			options: ['', 'Active', 'Inactive', 'Suspended', 'Broken']
 		},
 		{
-			type: 'select',
+			type: 'link',
 			label: 'Project',
 			fieldname: 'cluster',
-			options: clusterOptions
+			options: {
+				doctype: 'Cluster'
+			}
 		}
 	];
 }

--- a/dashboard/src2/objects/common/index.ts
+++ b/dashboard/src2/objects/common/index.ts
@@ -1,4 +1,5 @@
-import { defineAsyncComponent, h } from 'vue';
+import { createListResource } from 'frappe-ui';
+import { defineAsyncComponent, h, reactive } from 'vue';
 import { renderDialog } from '../../utils/components';
 import type {
 	BannerConfig,
@@ -12,19 +13,17 @@ import { planTitle } from '../../utils/format';
 
 export const unreachable = Error('unreachable'); // used to indicate that a codepath is unreachable
 
-export const clusterOptions = [
-	'',
-	'Bahrain',
-	'Cape Town',
-	'Frankfurt',
-	'KSA',
-	'London',
-	'Mumbai',
-	'Singapore',
-	'UAE',
-	'Virginia',
-	'Zurich'
-];
+export const clusterOptions: string[] = reactive(['']);
+
+createListResource({
+	doctype: 'Cluster',
+	fields: ['name', 'title'],
+	orderBy: 'title asc',
+	auto: true,
+	onSuccess(data: { name: string }[]) {
+		clusterOptions.splice(0, clusterOptions.length, '', ...data.map(c => c.name));
+	}
+});
 
 export function getUpsellBanner(site: DocumentResource, title: string) {
 	if (
@@ -72,7 +71,7 @@ export function getSitesTabColumns(forBenchTab: boolean) {
 			width: 0.5
 		},
 		{
-			label: 'Region',
+			label: 'Project',
 			fieldname: 'cluster_title',
 			width: 0.5,
 			prefix(row) {
@@ -107,21 +106,9 @@ export function siteTabFilterControls() {
 		},
 		{
 			type: 'select',
-			label: 'Region',
+			label: 'Project',
 			fieldname: 'cluster',
-			options: [
-				'',
-				'Bahrain',
-				'Cape Town',
-				'Frankfurt',
-				'KSA',
-				'London',
-				'Mumbai',
-				'Singapore',
-				'UAE',
-				'Virginia',
-				'Zurich'
-			]
+			options: clusterOptions
 		}
 	];
 }

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -103,36 +103,29 @@ export default {
 					options: ['', 'Active', 'Inactive', 'Suspended', 'Broken', 'Archived']
 				},
 				{
+					type: 'select',
+					label: 'Instance State',
+					fieldname: 'server.instance_state',
+					options: ['', 'Pending', 'Running', 'Stopped', 'Rebooting']
+				},
+				{
+					type: 'select',
+					label: 'Project',
+					fieldname: 'cluster',
+					options: clusterOptions
+				},
+				{
+					type: 'select',
+					label: 'Environment',
+					fieldname: 'server.environment',
+					options: ['', 'Development', 'Demo', 'Production']
+				},
+				{
 					type: 'link',
 					label: 'Version',
 					fieldname: 'group.version',
 					options: {
 						doctype: 'Frappe Version'
-					}
-				},
-				{
-					type: 'link',
-					label: 'Bench Group',
-					fieldname: 'group',
-					options: {
-						doctype: 'Release Group'
-					}
-				},
-				{
-					type: 'select',
-					label: 'Region',
-					fieldname: 'cluster',
-					options: clusterOptions
-				},
-				{
-					type: 'link',
-					label: 'Tag',
-					fieldname: 'tags.tag',
-					options: {
-						doctype: 'Press Tag',
-						filters: {
-							doctype_name: 'Site'
-						}
 					}
 				}
 			];

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -19,7 +19,7 @@ import { bytes, date, userCurrency } from '../utils/format';
 import { getToastErrorMessage } from '../utils/toast';
 import { getDocResource } from '../utils/resource';
 import { trialDays } from '../utils/site';
-import { clusterOptions, getUpsellBanner } from './common';
+import { getUpsellBanner } from './common';
 import { getAppsTab } from './common/apps';
 import { isMobile } from '../utils/device';
 
@@ -90,7 +90,8 @@ export default {
 			'cluster.image as cluster_image',
 			'cluster.title as cluster_title',
 			'trial_end_date',
-			'server.instance_state as server_instance_state'
+			'server.instance_state as server_instance_state',
+			'server.environment as server_environment'
 		],
 		orderBy: 'creation desc',
 		searchField: 'host_name',
@@ -109,10 +110,12 @@ export default {
 					options: ['', 'Pending', 'Running', 'Stopped', 'Rebooting']
 				},
 				{
-					type: 'select',
+					type: 'link',
 					label: 'Project',
 					fieldname: 'cluster',
-					options: clusterOptions
+					options: {
+						doctype: 'Cluster'
+					}
 				},
 				{
 					type: 'select',

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -100,12 +100,14 @@ export default {
 				{
 					type: 'select',
 					label: 'Status',
+					class: !isMobile() ? 'w-28' : '',
 					fieldname: 'status',
 					options: ['', 'Active', 'Inactive', 'Suspended', 'Broken', 'Archived']
 				},
 				{
 					type: 'select',
 					label: 'Instance State',
+					class: !isMobile() ? 'w-32' : '',
 					fieldname: 'server.instance_state',
 					options: ['', 'Pending', 'Running', 'Stopped', 'Rebooting']
 				},
@@ -120,6 +122,7 @@ export default {
 				{
 					type: 'select',
 					label: 'Environment',
+					class: !isMobile() ? 'w-32' : '',
 					fieldname: 'server.environment',
 					options: ['', 'Development', 'Demo', 'Production']
 				},

--- a/press/__init__.py
+++ b/press/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/press/api/bizkit_site.py
+++ b/press/api/bizkit_site.py
@@ -57,7 +57,7 @@ def _new(args):
         if is_new:
             print("Creating new client")
             print("Creating cluster")
-            cluster = create_cluster(project_name)
+            cluster = create_cluster(project_name, team)
             created["cluster"] = cluster
             print("Creating database server")
             db_server = create_database_server(project_name, cluster, site_plan_details)
@@ -208,7 +208,7 @@ def get_site_plan_details(site_plan):
     }
 
 
-def create_cluster(project_name):
+def create_cluster(project_name, team):
     cluster_doc = frappe.get_doc({
         "doctype": "Cluster",
         "name": project_name,
@@ -217,6 +217,7 @@ def create_cluster(project_name):
         "public": 1,
         "cloud_provider": "Generic",
         "region": "ap-southeast-1",
+        "team": team,
     })
     cluster_doc.insert()
     frappe.db.commit()

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -138,3 +138,4 @@ press.patches.v0_7_0.set_label_for_site_database_user
 press.press.doctype.press_settings.patches.set_redis_cache_size
 press.press.doctype.virtual_machine.patches.set_root_disk_size
 press.press.doctype.virtual_machine_image.patches.set_root_size
+press.patches.v0_8_0.set_cluster_team_to_devops

--- a/press/patches/v0_8_0/set_cluster_team_to_devops.py
+++ b/press/patches/v0_8_0/set_cluster_team_to_devops.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	team = frappe.db.get_value("Team", {"team_title": "DevOps"}, "name")
+	if not team:
+		return
+
+	clusters = frappe.get_all("Cluster", filters={"team": ("is", "not set")}, pluck="name")
+	for cluster in clusters:
+		frappe.db.set_value("Cluster", cluster, "team", team)

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -44,6 +44,7 @@ class BaseServer(Document, TagHelpers):
 		"is_self_hosted",
 		"auto_add_storage_min",
 		"auto_add_storage_max",
+		"environment",
 	)
 
 	@staticmethod


### PR DESCRIPTION
- Overhauled Site list filters — replaced Version, Bench Group, Region, and Tag filters with Instance State, Project, and Environment filters
- Exposed `server.environment` in Site list — added it to `dashboard_fields` and the site list query so it can be used as a filter
- Replaced hardcoded region filter with dynamic "Project" link filter across the Site, Bench, and Release Group dashboards — the static `clusterOptions` list (Bahrain, Cape Town, Frankfurt, etc.) is removed; filters now resolve Cluster docs dynamically
- Clusters now get a team assigned on creation — `create_cluster()` accepts a `team` param and sets it; existing clusters without a team are backfilled to "DevOps" via a v0.8.0 migration patch